### PR TITLE
Implement custom ByteBuffer

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -80,7 +80,7 @@
       </exec>
     </target>
 
-    <target name="truffle-libs" unless="skip.libs" depends="truffle,build-graal">
+    <target name="truffle-libs" unless="skip.truffle" depends="truffle,build-graal">
         <exec executable="${mx.cmd}" dir="${truffle.dir}" failonerror="true">
             <arg value="build"/>
             <arg value="--no-native"/>

--- a/core-lib/Benchmarks/AsyncHarness.ns
+++ b/core-lib/Benchmarks/AsyncHarness.ns
@@ -147,6 +147,9 @@ class AsyncHarness usingPlatform: platform = Value (
     )
 
     printRun: runTime = (
+      | stats = system traceStatistics. |
+      (name + ': trace size:    ' + (stats at: 1) + 'byte') println.
+      (name + ': external data: ' + (stats at: 2) + 'byte') println.
       (name + ': iterations=1' + ' runtime: ' + runTime + 'us') println
     )
 

--- a/core-lib/System.ns
+++ b/core-lib/System.ns
@@ -42,6 +42,9 @@ class System usingVmMirror: vmMirror = Value (
   public time  = ( ^ vmMirror systemTime: nil  )
   public ticks = ( ^ vmMirror systemTicks: nil ) (* returns the microseconds since start *)
 
+  (* Actor Tracing Statistics *)
+  public traceStatistics = ( ^ vmMirror traceStatistics: nil )
+
   (* Force Garbage Collection *)
   public fullGC = ( ^ vmMirror systemGC: nil )
 

--- a/libs/java8/Unsafe.java
+++ b/libs/java8/Unsafe.java
@@ -10,6 +10,10 @@ public final class Unsafe {
   }
 
   public native long objectFieldOffset(Field f);
+  
+  public native int arrayBaseOffset(Class<?> clazz);
+  
+  public native int arrayIndexScale(Class<?> clazz);
 
   public native Object getObject(Object o, long offset);
 

--- a/libs/java8/Unsafe.java
+++ b/libs/java8/Unsafe.java
@@ -15,6 +15,12 @@ public final class Unsafe {
 
   public native void putObject(Object o, long offset, Object value);
 
+  public native void putByte(Object o, long offset, byte value);
+
+  public native void putShort(Object o, long offset, short value);
+  
+  public native void putInt(Object o, long offset, int value);
+  
   public native long getLong(Object o, long offset);
 
   public native void putLong(Object o, long offset, long value);

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -27,7 +27,6 @@ import tools.concurrency.nodes.TraceActorContext;
 import tools.concurrency.nodes.TraceActorContextNodeGen;
 import tools.debugger.WebDebugger;
 import tools.debugger.entities.ActivityType;
-import tools.debugger.entities.DynamicScopeType;
 
 
 /**
@@ -273,17 +272,7 @@ public class Actor implements Activity {
         TracingActor.handleBreakpointsAndStepping(msg, dbg, actor);
       }
 
-      try {
-        if (VmSettings.MEDEOR_TRACING) {
-          MedeorTrace.scopeStart(DynamicScopeType.TURN, msg.getMessageId(),
-              msg.getTargetSourceSection());
-        }
-        msg.execute();
-      } finally {
-        if (VmSettings.MEDEOR_TRACING) {
-          MedeorTrace.scopeEnd(DynamicScopeType.TURN);
-        }
-      }
+      msg.execute();
     }
 
     private boolean getCurrentMessagesOrCompleteExecution() {

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -23,6 +23,8 @@ import tools.concurrency.MedeorTrace;
 import tools.concurrency.TracingActivityThread;
 import tools.concurrency.TracingActors.ReplayActor;
 import tools.concurrency.TracingActors.TracingActor;
+import tools.concurrency.nodes.TraceActorContext;
+import tools.concurrency.nodes.TraceActorContextNodeGen;
 import tools.debugger.WebDebugger;
 import tools.debugger.entities.ActivityType;
 import tools.debugger.entities.DynamicScopeType;
@@ -219,6 +221,8 @@ public class Actor implements Activity {
       this.vm = vm;
     }
 
+    private static final TraceActorContext tracer = TraceActorContextNodeGen.create();
+
     @Override
     public void run() {
       ObjectTransitionSafepoint.INSTANCE.register();
@@ -233,7 +237,7 @@ public class Actor implements Activity {
       t.currentlyExecutingActor = actor;
 
       if (VmSettings.ACTOR_TRACING) {
-        ActorExecutionTrace.recordActorContext((TracingActor) actor);
+        ActorExecutionTrace.recordActorContext((TracingActor) actor, tracer);
       } else if (VmSettings.MEDEOR_TRACING) {
         MedeorTrace.currentActivity(actor);
       }
@@ -276,7 +280,7 @@ public class Actor implements Activity {
         }
         msg.execute();
         if (VmSettings.ACTOR_TRACING) {
-          ActorExecutionTrace.recordMessage(msg);
+          ActorExecutionTrace.recordMessage(msg, tracer);
         }
 
       } finally {

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -279,10 +279,6 @@ public class Actor implements Activity {
               msg.getTargetSourceSection());
         }
         msg.execute();
-        if (VmSettings.ACTOR_TRACING) {
-          ActorExecutionTrace.recordMessage(msg, tracer);
-        }
-
       } finally {
         if (VmSettings.MEDEOR_TRACING) {
           MedeorTrace.scopeEnd(DynamicScopeType.TURN);

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -233,7 +233,7 @@ public class Actor implements Activity {
       t.currentlyExecutingActor = actor;
 
       if (VmSettings.ACTOR_TRACING) {
-        ActorExecutionTrace.recordActorContext(actor);
+        ActorExecutionTrace.recordActorContext((TracingActor) actor);
       } else if (VmSettings.MEDEOR_TRACING) {
         MedeorTrace.currentActivity(actor);
       }

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -23,7 +23,7 @@ import tools.concurrency.MedeorTrace;
 import tools.concurrency.TracingActivityThread;
 import tools.concurrency.TracingActors.ReplayActor;
 import tools.concurrency.TracingActors.TracingActor;
-import tools.concurrency.nodes.TraceActorContext;
+import tools.concurrency.nodes.TraceActorContextNode;
 import tools.concurrency.nodes.TraceActorContextNodeGen;
 import tools.debugger.WebDebugger;
 import tools.debugger.entities.ActivityType;
@@ -220,7 +220,7 @@ public class Actor implements Activity {
       this.vm = vm;
     }
 
-    private static final TraceActorContext tracer = TraceActorContextNodeGen.create();
+    private static final TraceActorContextNode tracer = TraceActorContextNodeGen.create();
 
     @Override
     public void run() {

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -24,7 +24,6 @@ import tools.concurrency.TracingActivityThread;
 import tools.concurrency.TracingActors.ReplayActor;
 import tools.concurrency.TracingActors.TracingActor;
 import tools.concurrency.nodes.TraceActorContextNode;
-import tools.concurrency.nodes.TraceActorContextNodeGen;
 import tools.debugger.WebDebugger;
 import tools.debugger.entities.ActivityType;
 
@@ -208,7 +207,7 @@ public class Actor implements Activity {
       this.vm = vm;
     }
 
-    private static final TraceActorContextNode tracer = TraceActorContextNodeGen.create();
+    private static final TraceActorContextNode tracer = new TraceActorContextNode();
 
     @Override
     public void run() {

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -236,6 +236,10 @@ public class Actor implements Activity {
         ObjectTransitionSafepoint.INSTANCE.unregister();
       }
 
+      if (VmSettings.ACTOR_TRACING && t.swapTracingBuffer) {
+        t.getBuffer().swapStorage();
+        t.swapTracingBuffer = false;
+      }
       t.currentlyExecutingActor = null;
     }
 
@@ -314,7 +318,7 @@ public class Actor implements Activity {
   public static final class ActorProcessingThread extends TracingActivityThread {
     public EventualMessage currentMessage;
 
-    protected Actor currentlyExecutingActor;
+    public Actor currentlyExecutingActor;
 
     protected ActorProcessingThread(final ForkJoinPool pool) {
       super(pool);

--- a/src/som/interpreter/actors/Actor.java
+++ b/src/som/interpreter/actors/Actor.java
@@ -96,18 +96,6 @@ public class Actor implements Activity {
     return ActivityType.ACTOR;
   }
 
-  public int getActorId() {
-    return 0;
-  }
-
-  public short getOrdering() {
-    return 0;
-  }
-
-  public int getDataId() {
-    return 0;
-  }
-
   protected ExecAllMessages createExecutor(final VM vm) {
     return new ExecAllMessages(this, vm);
   }

--- a/src/som/interpreter/actors/ReceivedMessage.java
+++ b/src/som/interpreter/actors/ReceivedMessage.java
@@ -30,7 +30,7 @@ public class ReceivedMessage extends ReceivedRootNode {
   }
 
   @Override
-  public Object execute(final VirtualFrame frame) {
+  protected Object executeBody(final VirtualFrame frame) {
     EventualMessage msg = (EventualMessage) SArguments.rcvr(frame);
     boolean haltOnResolver = msg.getHaltOnResolver();
     boolean haltOnResolution = msg.getHaltOnResolution();
@@ -65,7 +65,7 @@ public class ReceivedMessage extends ReceivedRootNode {
     }
 
     @Override
-    public Object execute(final VirtualFrame frame) {
+    protected Object executeBody(final VirtualFrame frame) {
       EventualMessage msg = (EventualMessage) SArguments.rcvr(frame);
 
       if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.getHaltOnResolver()) {
@@ -88,7 +88,7 @@ public class ReceivedMessage extends ReceivedRootNode {
     }
 
     @Override
-    public Object execute(final VirtualFrame frame) {
+    protected Object executeBody(final VirtualFrame frame) {
       EventualMessage msg = (EventualMessage) SArguments.rcvr(frame);
       boolean haltOnResolver = msg.getHaltOnResolver();
       boolean haltOnResolution = msg.getHaltOnResolution();

--- a/src/som/interpreter/actors/ReceivedMessage.java
+++ b/src/som/interpreter/actors/ReceivedMessage.java
@@ -7,11 +7,9 @@ import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 
-import som.interpreter.SArguments;
 import som.interpreter.SomException;
 import som.interpreter.SomLanguage;
 import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
-import som.vm.VmSettings;
 import som.vmobjects.SSymbol;
 
 
@@ -30,15 +28,8 @@ public class ReceivedMessage extends ReceivedRootNode {
   }
 
   @Override
-  protected Object executeBody(final VirtualFrame frame) {
-    EventualMessage msg = (EventualMessage) SArguments.rcvr(frame);
-    boolean haltOnResolver = msg.getHaltOnResolver();
-    boolean haltOnResolution = msg.getHaltOnResolution();
-
-    if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && haltOnResolver) {
-      dbg.prepareSteppingAfterNextRootNode();
-    }
-
+  protected Object executeBody(final VirtualFrame frame, final EventualMessage msg,
+      final boolean haltOnResolver, final boolean haltOnResolution) {
     try {
       Object result = onReceive.doPreEvaluated(frame, msg.args);
       resolvePromise(frame, msg.resolver, result, haltOnResolver, haltOnResolution);
@@ -65,13 +56,8 @@ public class ReceivedMessage extends ReceivedRootNode {
     }
 
     @Override
-    protected Object executeBody(final VirtualFrame frame) {
-      EventualMessage msg = (EventualMessage) SArguments.rcvr(frame);
-
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && msg.getHaltOnResolver()) {
-        dbg.prepareSteppingAfterNextRootNode();
-      }
-
+    protected Object executeBody(final VirtualFrame frame, final EventualMessage msg,
+        final boolean haltOnResolver, final boolean haltOnResolution) {
       Object result = onReceive.doPreEvaluated(frame, msg.args);
       future.complete(result);
       return result;
@@ -88,15 +74,8 @@ public class ReceivedMessage extends ReceivedRootNode {
     }
 
     @Override
-    protected Object executeBody(final VirtualFrame frame) {
-      EventualMessage msg = (EventualMessage) SArguments.rcvr(frame);
-      boolean haltOnResolver = msg.getHaltOnResolver();
-      boolean haltOnResolution = msg.getHaltOnResolution();
-
-      if (VmSettings.TRUFFLE_DEBUGGER_ENABLED && haltOnResolver) {
-        dbg.prepareSteppingAfterNextRootNode();
-      }
-
+    protected Object executeBody(final VirtualFrame frame, final EventualMessage msg,
+        final boolean haltOnResolver, final boolean haltOnResolution) {
       try {
         Object result = onReceive.call(msg.args);
         resolvePromise(frame, msg.resolver, result, haltOnResolver,

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.RootNode;
-import com.oracle.truffle.api.profiles.ValueProfile;
 import com.oracle.truffle.api.source.SourceSection;
 
 import som.VM;
@@ -12,10 +11,9 @@ import som.interpreter.SArguments;
 import som.interpreter.SomLanguage;
 import som.interpreter.actors.SPromise.SResolver;
 import som.vm.VmSettings;
-import tools.concurrency.ActorExecutionTrace;
 import tools.concurrency.MedeorTrace;
-import tools.concurrency.nodes.TraceActorContextNode;
-import tools.concurrency.nodes.TraceActorContextNodeGen;
+import tools.concurrency.nodes.TraceMessageNode;
+import tools.concurrency.nodes.TraceMessageNodeGen;
 import tools.debugger.WebDebugger;
 import tools.debugger.entities.DynamicScopeType;
 
@@ -25,9 +23,7 @@ public abstract class ReceivedRootNode extends RootNode {
   @Child protected AbstractPromiseResolutionNode resolve;
   @Child protected AbstractPromiseResolutionNode error;
 
-  @Child protected TraceActorContextNode tracer = TraceActorContextNodeGen.create();
-
-  private final ValueProfile msgProfile = ValueProfile.createClassProfile();
+  @Child protected TraceMessageNode msgTracer = TraceMessageNodeGen.create();
 
   private final VM            vm;
   protected final WebDebugger dbg;
@@ -77,7 +73,7 @@ public abstract class ReceivedRootNode extends RootNode {
       return executeBody(frame, msg, haltOnResolver, haltOnResolution);
     } finally {
       if (VmSettings.ACTOR_TRACING) {
-        ActorExecutionTrace.recordMessage(msgProfile.profile(msg), tracer);
+        msgTracer.execute(msg);
       }
 
       if (VmSettings.MEDEOR_TRACING) {

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -14,7 +14,7 @@ import som.interpreter.actors.SPromise.SResolver;
 import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace;
 import tools.concurrency.MedeorTrace;
-import tools.concurrency.nodes.TraceActorContext;
+import tools.concurrency.nodes.TraceActorContextNode;
 import tools.concurrency.nodes.TraceActorContextNodeGen;
 import tools.debugger.WebDebugger;
 import tools.debugger.entities.DynamicScopeType;
@@ -25,7 +25,7 @@ public abstract class ReceivedRootNode extends RootNode {
   @Child protected AbstractPromiseResolutionNode resolve;
   @Child protected AbstractPromiseResolutionNode error;
 
-  @Child protected TraceActorContext tracer = TraceActorContextNodeGen.create();
+  @Child protected TraceActorContextNode tracer = TraceActorContextNodeGen.create();
 
   private final ValueProfile msgProfile = ValueProfile.createClassProfile();
 

--- a/src/som/interpreter/actors/ReceivedRootNode.java
+++ b/src/som/interpreter/actors/ReceivedRootNode.java
@@ -13,9 +13,11 @@ import som.interpreter.SomLanguage;
 import som.interpreter.actors.SPromise.SResolver;
 import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.MedeorTrace;
 import tools.concurrency.nodes.TraceActorContext;
 import tools.concurrency.nodes.TraceActorContextNodeGen;
 import tools.debugger.WebDebugger;
+import tools.debugger.entities.DynamicScopeType;
 
 
 public abstract class ReceivedRootNode extends RootNode {
@@ -66,11 +68,20 @@ public abstract class ReceivedRootNode extends RootNode {
       haltOnResolution = false;
     }
 
+    if (VmSettings.MEDEOR_TRACING) {
+      MedeorTrace.scopeStart(DynamicScopeType.TURN, msg.getMessageId(),
+          msg.getTargetSourceSection());
+    }
+
     try {
       return executeBody(frame, msg, haltOnResolver, haltOnResolution);
     } finally {
       if (VmSettings.ACTOR_TRACING) {
         ActorExecutionTrace.recordMessage(msgProfile.profile(msg), tracer);
+      }
+
+      if (VmSettings.MEDEOR_TRACING) {
+        MedeorTrace.scopeEnd(DynamicScopeType.TURN);
       }
     }
   }

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -51,7 +51,7 @@ import som.vmobjects.SObjectWithClass;
 import som.vmobjects.SSymbol;
 import tools.SourceCoordinate;
 import tools.concurrency.ActorExecutionTrace;
-import tools.concurrency.nodes.TraceActorContext;
+import tools.concurrency.nodes.TraceActorContextNode;
 import tools.concurrency.nodes.TraceActorContextNodeGen;
 
 
@@ -254,7 +254,7 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemTime:")
   public abstract static class TimePrim extends UnaryBasicOperation {
-    @Child TraceActorContext tracer = TraceActorContextNodeGen.create();
+    @Child TraceActorContextNode tracer = TraceActorContextNodeGen.create();
 
     @Specialization
     public final long doSObject(final Object receiver) {
@@ -286,7 +286,7 @@ public final class SystemPrims {
   @Primitive(primitive = "systemTicks:", selector = "ticks",
       specializer = IsSystemModule.class, noWrapper = true)
   public abstract static class TicksPrim extends UnaryBasicOperation implements Operation {
-    @Child TraceActorContext tracer = TraceActorContextNodeGen.create();
+    @Child TraceActorContextNode tracer = TraceActorContextNodeGen.create();
 
     @Specialization
     public final long doSObject(final Object receiver) {

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -52,7 +52,6 @@ import som.vmobjects.SSymbol;
 import tools.SourceCoordinate;
 import tools.concurrency.ActorExecutionTrace;
 import tools.concurrency.nodes.TraceActorContextNode;
-import tools.concurrency.nodes.TraceActorContextNodeGen;
 
 
 public final class SystemPrims {
@@ -254,7 +253,7 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemTime:")
   public abstract static class TimePrim extends UnaryBasicOperation {
-    @Child TraceActorContextNode tracer = TraceActorContextNodeGen.create();
+    @Child TraceActorContextNode tracer = new TraceActorContextNode();
 
     @Specialization
     public final long doSObject(final Object receiver) {
@@ -286,7 +285,7 @@ public final class SystemPrims {
   @Primitive(primitive = "systemTicks:", selector = "ticks",
       specializer = IsSystemModule.class, noWrapper = true)
   public abstract static class TicksPrim extends UnaryBasicOperation implements Operation {
-    @Child TraceActorContextNode tracer = TraceActorContextNodeGen.create();
+    @Child TraceActorContextNode tracer = new TraceActorContextNode();
 
     @Specialization
     public final long doSObject(final Object receiver) {

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -51,6 +51,8 @@ import som.vmobjects.SObjectWithClass;
 import som.vmobjects.SSymbol;
 import tools.SourceCoordinate;
 import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.nodes.TraceActorContext;
+import tools.concurrency.nodes.TraceActorContextNodeGen;
 
 
 public final class SystemPrims {
@@ -252,11 +254,13 @@ public final class SystemPrims {
   @GenerateNodeFactory
   @Primitive(primitive = "systemTime:")
   public abstract static class TimePrim extends UnaryBasicOperation {
+    @Child TraceActorContext tracer = TraceActorContextNodeGen.create();
+
     @Specialization
     public final long doSObject(final Object receiver) {
       long res = System.currentTimeMillis() - startTime;
       if (VmSettings.ACTOR_TRACING) {
-        ActorExecutionTrace.longSystemCall(res);
+        ActorExecutionTrace.longSystemCall(res, tracer);
       }
       return res;
     }
@@ -282,11 +286,13 @@ public final class SystemPrims {
   @Primitive(primitive = "systemTicks:", selector = "ticks",
       specializer = IsSystemModule.class, noWrapper = true)
   public abstract static class TicksPrim extends UnaryBasicOperation implements Operation {
+    @Child TraceActorContext tracer = TraceActorContextNodeGen.create();
+
     @Specialization
     public final long doSObject(final Object receiver) {
       long res = System.nanoTime() / 1000L - startMicroTime;
       if (VmSettings.ACTOR_TRACING) {
-        ActorExecutionTrace.longSystemCall(res);
+        ActorExecutionTrace.longSystemCall(res, tracer);
       }
       return res;
     }

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -51,6 +51,7 @@ import som.vmobjects.SObjectWithClass;
 import som.vmobjects.SSymbol;
 import tools.SourceCoordinate;
 import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.TracingBackend;
 import tools.concurrency.nodes.TraceActorContextNode;
 
 
@@ -65,6 +66,17 @@ public final class SystemPrims {
     public final Object set(final SObjectWithClass system) {
       SystemModule = system;
       return system;
+    }
+  }
+
+  @GenerateNodeFactory
+  @Primitive(primitive = "traceStatistics:")
+  public abstract static class TraceStatisticsPrim extends UnarySystemOperation {
+    @Specialization
+    @TruffleBoundary
+    public final Object doSObject(final Object module) {
+      long[] stats = TracingBackend.forceSwapBuffersAndGetStatistics();
+      return new SImmutableArray(stats, Classes.valueArrayClass);
     }
   }
 

--- a/src/som/primitives/TimerPrim.java
+++ b/src/som/primitives/TimerPrim.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.profiles.ValueProfile;
 
 import bd.primitives.Primitive;
 import som.VM;
@@ -27,6 +28,8 @@ public abstract class TimerPrim extends BinarySystemOperation {
 
   @Child protected WrapReferenceNode wrapper = WrapReferenceNodeGen.create();
 
+  private final ValueProfile whenResolvedProfile = ValueProfile.createClassProfile();
+
   @Override
   public final TimerPrim initialize(final VM vm) {
     super.initialize(vm);
@@ -45,7 +48,7 @@ public abstract class TimerPrim extends BinarySystemOperation {
       public void run() {
         ResolvePromiseNode.resolve(Resolution.SUCCESSFUL, wrapper,
             resolver.getPromise(), true,
-            resolver.getPromise().getOwner(), actorPool, false);
+            resolver.getPromise().getOwner(), actorPool, false, whenResolvedProfile);
       }
     }, timeout);
     return true;

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -13,9 +13,11 @@ import som.primitives.actors.PromisePrims.IsActorModule;
 import som.vm.VmSettings;
 import som.vm.constants.KernelObj;
 import som.vmobjects.SClass;
-import tools.concurrency.ActorExecutionTrace;
 import tools.concurrency.MedeorTrace;
 import tools.concurrency.Tags.ExpressionBreakpoint;
+import tools.concurrency.TracingActors.TracingActor;
+import tools.concurrency.nodes.TraceActorCreation;
+import tools.concurrency.nodes.TraceActorCreationNodeGen;
 import tools.debugger.entities.ActivityType;
 
 
@@ -23,7 +25,8 @@ import tools.debugger.entities.ActivityType;
 @Primitive(primitive = "actors:createFromValue:", selector = "createActorFromValue:",
     specializer = IsActorModule.class)
 public abstract class CreateActorPrim extends BinarySystemOperation {
-  @Child protected IsValue isValue = IsValueNodeGen.createSubNode();
+  @Child protected IsValue            isValue = IsValueNodeGen.createSubNode();
+  @Child protected TraceActorCreation trace   = TraceActorCreationNodeGen.create();
 
   @Specialization(guards = "isValue.executeEvaluated(argument)")
   public final SFarReference createActor(final Object receiver, final Object argument) {
@@ -31,7 +34,7 @@ public abstract class CreateActorPrim extends BinarySystemOperation {
     SFarReference ref = new SFarReference(actor, argument);
 
     if (VmSettings.ACTOR_TRACING) {
-      ActorExecutionTrace.recordActorCreation(actor.getActorId());
+      trace.execute((TracingActor) actor);
     } else if (VmSettings.MEDEOR_TRACING) {
       assert argument instanceof SClass;
       final SClass actorClass = (SClass) argument;

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -17,7 +17,6 @@ import tools.concurrency.MedeorTrace;
 import tools.concurrency.Tags.ExpressionBreakpoint;
 import tools.concurrency.TracingActors.TracingActor;
 import tools.concurrency.nodes.TraceActorCreationNode;
-import tools.concurrency.nodes.TraceActorCreationNodeGen;
 import tools.debugger.entities.ActivityType;
 
 
@@ -25,8 +24,8 @@ import tools.debugger.entities.ActivityType;
 @Primitive(primitive = "actors:createFromValue:", selector = "createActorFromValue:",
     specializer = IsActorModule.class)
 public abstract class CreateActorPrim extends BinarySystemOperation {
-  @Child protected IsValue            isValue = IsValueNodeGen.createSubNode();
-  @Child protected TraceActorCreationNode trace   = TraceActorCreationNodeGen.create();
+  @Child protected IsValue                isValue = IsValueNodeGen.createSubNode();
+  @Child protected TraceActorCreationNode trace   = new TraceActorCreationNode();
 
   @Specialization(guards = "isValue.executeEvaluated(argument)")
   public final SFarReference createActor(final Object receiver, final Object argument) {
@@ -34,7 +33,7 @@ public abstract class CreateActorPrim extends BinarySystemOperation {
     SFarReference ref = new SFarReference(actor, argument);
 
     if (VmSettings.ACTOR_TRACING) {
-      trace.execute((TracingActor) actor);
+      trace.trace((TracingActor) actor);
     } else if (VmSettings.MEDEOR_TRACING) {
       assert argument instanceof SClass;
       final SClass actorClass = (SClass) argument;

--- a/src/som/primitives/actors/CreateActorPrim.java
+++ b/src/som/primitives/actors/CreateActorPrim.java
@@ -16,7 +16,7 @@ import som.vmobjects.SClass;
 import tools.concurrency.MedeorTrace;
 import tools.concurrency.Tags.ExpressionBreakpoint;
 import tools.concurrency.TracingActors.TracingActor;
-import tools.concurrency.nodes.TraceActorCreation;
+import tools.concurrency.nodes.TraceActorCreationNode;
 import tools.concurrency.nodes.TraceActorCreationNodeGen;
 import tools.debugger.entities.ActivityType;
 
@@ -26,7 +26,7 @@ import tools.debugger.entities.ActivityType;
     specializer = IsActorModule.class)
 public abstract class CreateActorPrim extends BinarySystemOperation {
   @Child protected IsValue            isValue = IsValueNodeGen.createSubNode();
-  @Child protected TraceActorCreation trace   = TraceActorCreationNodeGen.create();
+  @Child protected TraceActorCreationNode trace   = TraceActorCreationNodeGen.create();
 
   @Specialization(guards = "isValue.executeEvaluated(argument)")
   public final SFarReference createActor(final Object receiver, final Object argument) {

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -47,7 +47,7 @@ public class VmSettings implements Settings {
         System.getProperty("som.traceFile", System.getProperty("user.dir") + "/traces/trace");
     MEMORY_TRACING = getBool("som.memoryTracing", false);
     REPLAY = getBool("som.replay", false);
-    MEDEOR_TRACING = false; // REPLAY;
+    MEDEOR_TRACING = TRUFFLE_DEBUGGER_ENABLED; // REPLAY;
     DISABLE_TRACE_FILE = getBool("som.disableTraceFile", false) || REPLAY;
     TRACE_SMALL_IDS = getBool("som.smallIds", false);
 

--- a/src/som/vmobjects/SArray.java
+++ b/src/som/vmobjects/SArray.java
@@ -21,12 +21,12 @@ public abstract class SArray extends SAbstractObject {
   protected Object       storage;
   protected final SClass clazz;
 
-  public SArray(final long length, final SClass clazz) {
+  protected SArray(final long length, final SClass clazz) {
     storage = (int) length;
     this.clazz = clazz;
   }
 
-  public SArray(final Object storage, final SClass clazz) {
+  protected SArray(final Object storage, final SClass clazz) {
     assert !(storage instanceof Long);
     assert storage != null;
     this.storage = storage;
@@ -201,7 +201,7 @@ public abstract class SArray extends SAbstractObject {
 
     /**
      * Creates and empty array, using the EMPTY strategy.
-     * 
+     *
      * @param length
      */
     public SMutableArray(final long length, final SClass clazz) {
@@ -264,7 +264,7 @@ public abstract class SArray extends SAbstractObject {
     /**
      * For internal use only, specifically, for SClass.
      * There we now, it is either empty, or of OBJECT type.
-     * 
+     *
      * @param value
      * @return new mutable array extended by value
      */

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -6,7 +6,7 @@ import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.interpreter.actors.SPromise.STracingPromise;
 import som.vm.VmSettings;
 import tools.concurrency.TracingActors.TracingActor;
-import tools.concurrency.nodes.TraceActorContext;
+import tools.concurrency.nodes.TraceActorContextNode;
 
 
 public class ActorExecutionTrace {
@@ -26,12 +26,12 @@ public class ActorExecutionTrace {
   }
 
   public static void recordActorContext(final TracingActor actor,
-      final TraceActorContext tracer) {
+      final TraceActorContextNode tracer) {
     TracingActivityThread t = getThread();
     ((ActorTraceBuffer) t.getBuffer()).recordActorContext(actor, tracer);
   }
 
-  public static void recordMessage(final EventualMessage msg, final TraceActorContext tracer) {
+  public static void recordMessage(final EventualMessage msg, final TraceActorContextNode tracer) {
     TracingActivityThread t = getThread();
     ActorTraceBuffer atb = ((ActorTraceBuffer) t.getBuffer());
     if (msg instanceof ExternalMessage) {
@@ -55,12 +55,12 @@ public class ActorExecutionTrace {
     }
   }
 
-  public static void recordSystemCall(final int dataId, final TraceActorContext tracer) {
+  public static void recordSystemCall(final int dataId, final TraceActorContextNode tracer) {
     TracingActivityThread t = getThread();
     ((ActorTraceBuffer) t.getBuffer()).recordSystemCall(dataId, tracer);
   }
 
-  public static void intSystemCall(final int i, final TraceActorContext tracer) {
+  public static void intSystemCall(final int i, final TraceActorContextNode tracer) {
     TracingActor ta = (TracingActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
     int dataId = ta.getActorId();
     ByteBuffer b = getExtDataByteBuffer(ta.getActorId(), dataId, Integer.BYTES);
@@ -69,7 +69,7 @@ public class ActorExecutionTrace {
     recordExternalData(b);
   }
 
-  public static void longSystemCall(final long l, final TraceActorContext tracer) {
+  public static void longSystemCall(final long l, final TraceActorContextNode tracer) {
     TracingActor ta = (TracingActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
     int dataId = ta.getActorId();
     ByteBuffer b = getExtDataByteBuffer(ta.getActorId(), dataId, Long.BYTES);
@@ -78,7 +78,7 @@ public class ActorExecutionTrace {
     recordExternalData(b);
   }
 
-  public static void doubleSystemCall(final double d, final TraceActorContext tracer) {
+  public static void doubleSystemCall(final double d, final TraceActorContextNode tracer) {
     TracingActor ta = (TracingActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
     int dataId = ta.getActorId();
     ByteBuffer b = getExtDataByteBuffer(ta.getActorId(), dataId, Double.BYTES);
@@ -87,7 +87,7 @@ public class ActorExecutionTrace {
     recordExternalData(b);
   }
 
-  public static void stringSystemCall(final String s, final TraceActorContext tracer) {
+  public static void stringSystemCall(final String s, final TraceActorContextNode tracer) {
     TracingActor ta = (TracingActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
     int dataId = ta.getActorId();
     ByteBuffer b = getExtDataByteBuffer(ta.getActorId(), dataId, s.getBytes().length);
@@ -113,7 +113,7 @@ public class ActorExecutionTrace {
     TracingActor currentActor;
 
     @Override
-    protected void swapBufferWhenNotEnoughSpace(final TraceActorContext tracer) {
+    protected void swapBufferWhenNotEnoughSpace(final TraceActorContextNode tracer) {
       boolean didSwap = swapStorage();
       assert didSwap;
       tracer.execute(currentActor);
@@ -132,13 +132,13 @@ public class ActorExecutionTrace {
       return 3;
     }
 
-    public void recordActorContext(final TracingActor actor, final TraceActorContext tracer) {
+    public void recordActorContext(final TracingActor actor, final TraceActorContextNode tracer) {
       ensureSufficientSpace(7, tracer);
       currentActor = actor;
       tracer.execute(actor);
     }
 
-    public void recordMessage(final int senderId, final TraceActorContext tracer) {
+    public void recordMessage(final int senderId, final TraceActorContextNode tracer) {
       ensureSufficientSpace(5, tracer);
       if (VmSettings.TRACE_SMALL_IDS) {
         int usedBytes = getUsedBytes(senderId);
@@ -150,7 +150,7 @@ public class ActorExecutionTrace {
     }
 
     public void recordPromiseMessage(final int senderId, final int resolverId,
-        final TraceActorContext tracer) {
+        final TraceActorContextNode tracer) {
       ensureSufficientSpace(9, tracer);
       int usedBytes = Math.max(getUsedBytes(resolverId), getUsedBytes(senderId));
 
@@ -164,7 +164,7 @@ public class ActorExecutionTrace {
     }
 
     public void recordExternalMessage(final int senderId, final short method,
-        final int dataId, final TraceActorContext tracer) {
+        final int dataId, final TraceActorContextNode tracer) {
       ensureSufficientSpace(11, tracer);
 
       if (VmSettings.TRACE_SMALL_IDS) {
@@ -178,7 +178,7 @@ public class ActorExecutionTrace {
     }
 
     public void recordExternalPromiseMessage(final int senderId, final int resolverId,
-        final short method, final int dataId, final TraceActorContext tracer) {
+        final short method, final int dataId, final TraceActorContextNode tracer) {
       ensureSufficientSpace(15, tracer);
 
       if (VmSettings.TRACE_SMALL_IDS) {
@@ -195,7 +195,7 @@ public class ActorExecutionTrace {
       storage.putShortInt(method, senderId);
     }
 
-    public void recordSystemCall(final int dataId, final TraceActorContext tracer) {
+    public void recordSystemCall(final int dataId, final TraceActorContextNode tracer) {
       ensureSufficientSpace(5, tracer);
       storage.putByteInt(SYSTEM_CALL, dataId);
     }

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -136,11 +136,11 @@ public class ActorExecutionTrace {
 
     public void recordActorContext(final TracingActor actor) {
       ensureSufficientSpace(7);
+      currentActor = actor;
       recordActorContextWithoutBufferCheck(actor);
     }
 
     private void recordActorContextWithoutBufferCheck(final TracingActor actor) {
-      currentActor = actor;
       int id = actor.getActorId();
 
       if (VmSettings.TRACE_SMALL_IDS) {

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -149,9 +149,8 @@ public class ActorExecutionTrace {
         storage.putShort(actor.getOrdering());
         writeId(usedBytes, id);
       } else {
-        storage.put((byte) (ACTOR_CONTEXT | (3 << 4)));
-        storage.putShort(actor.getOrdering());
-        storage.putInt(id);
+      storage.putByteShortShort(
+          (byte) (ACTOR_CONTEXT | (usedBytes << 4)), actor.getOrdering(), (short) id);
       }
     }
 
@@ -162,8 +161,7 @@ public class ActorExecutionTrace {
         storage.put((byte) (ACTOR_CREATION | (usedBytes << 4)));
         writeId(usedBytes, childId);
       } else {
-        storage.put((byte) (ACTOR_CREATION | (3 << 4)));
-        storage.putInt(childId);
+      storage.putByteShort((byte) (ACTOR_CREATION | (usedBytes << 4)), (short) childId);
       }
     }
 

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -6,6 +6,7 @@ import som.interpreter.actors.EventualMessage.PromiseMessage;
 import som.interpreter.actors.SPromise.STracingPromise;
 import som.vm.VmSettings;
 import tools.concurrency.TracingActors.TracingActor;
+import tools.concurrency.nodes.TraceActorContext;
 
 
 public class ActorExecutionTrace {
@@ -24,9 +25,10 @@ public class ActorExecutionTrace {
     return (TracingActivityThread) current;
   }
 
-  public static void recordActorContext(final TracingActor actor) {
+  public static void recordActorContext(final TracingActor actor,
+      final TraceActorContext tracer) {
     TracingActivityThread t = getThread();
-    ((ActorTraceBuffer) t.getBuffer()).recordActorContext(actor);
+    ((ActorTraceBuffer) t.getBuffer()).recordActorContext(actor, tracer);
   }
 
   public static void recordActorCreation(final int childId) {
@@ -34,7 +36,7 @@ public class ActorExecutionTrace {
     ((ActorTraceBuffer) t.getBuffer()).recordActorCreation(childId);
   }
 
-  public static void recordMessage(final EventualMessage msg) {
+  public static void recordMessage(final EventualMessage msg, final TraceActorContext tracer) {
     TracingActivityThread t = getThread();
     ActorTraceBuffer atb = ((ActorTraceBuffer) t.getBuffer());
     if (msg instanceof ExternalMessage) {
@@ -42,59 +44,60 @@ public class ActorExecutionTrace {
       if (msg instanceof PromiseMessage) {
         atb.recordExternalPromiseMessage(msg.getSender().getActorId(),
             ((STracingPromise) ((PromiseMessage) msg).getPromise()).getResolvingActor(),
-            em.getMethod(), em.getDataId());
+            em.getMethod(), em.getDataId(), tracer);
       } else {
         atb.recordExternalMessage(msg.getSender().getActorId(), em.getMethod(),
-            em.getDataId());
+            em.getDataId(), tracer);
       }
     } else {
       if (msg instanceof PromiseMessage) {
         atb.recordPromiseMessage(msg.getSender().getActorId(),
-            ((STracingPromise) ((PromiseMessage) msg).getPromise()).getResolvingActor());
+            ((STracingPromise) ((PromiseMessage) msg).getPromise()).getResolvingActor(),
+            tracer);
       } else {
-        atb.recordMessage(msg.getSender().getActorId());
+        atb.recordMessage(msg.getSender().getActorId(), tracer);
       }
     }
   }
 
-  public static void recordSystemCall(final int dataId) {
+  public static void recordSystemCall(final int dataId, final TraceActorContext tracer) {
     TracingActivityThread t = getThread();
-    ((ActorTraceBuffer) t.getBuffer()).recordSystemCall(dataId);
+    ((ActorTraceBuffer) t.getBuffer()).recordSystemCall(dataId, tracer);
   }
 
-  public static void intSystemCall(final int i) {
+  public static void intSystemCall(final int i, final TraceActorContext tracer) {
     TracingActor ta = (TracingActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
     int dataId = ta.getActorId();
     ByteBuffer b = getExtDataByteBuffer(ta.getActorId(), dataId, Integer.BYTES);
     b.putInt(i);
-    recordSystemCall(dataId);
+    recordSystemCall(dataId, tracer);
     recordExternalData(b);
   }
 
-  public static void longSystemCall(final long l) {
+  public static void longSystemCall(final long l, final TraceActorContext tracer) {
     TracingActor ta = (TracingActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
     int dataId = ta.getActorId();
     ByteBuffer b = getExtDataByteBuffer(ta.getActorId(), dataId, Long.BYTES);
     b.putLong(l);
-    recordSystemCall(dataId);
+    recordSystemCall(dataId, tracer);
     recordExternalData(b);
   }
 
-  public static void doubleSystemCall(final double d) {
+  public static void doubleSystemCall(final double d, final TraceActorContext tracer) {
     TracingActor ta = (TracingActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
     int dataId = ta.getActorId();
     ByteBuffer b = getExtDataByteBuffer(ta.getActorId(), dataId, Double.BYTES);
     b.putDouble(d);
-    recordSystemCall(dataId);
+    recordSystemCall(dataId, tracer);
     recordExternalData(b);
   }
 
-  public static void stringSystemCall(final String s) {
+  public static void stringSystemCall(final String s, final TraceActorContext tracer) {
     TracingActor ta = (TracingActor) EventualMessage.getActorCurrentMessageIsExecutionOn();
     int dataId = ta.getActorId();
     ByteBuffer b = getExtDataByteBuffer(ta.getActorId(), dataId, s.getBytes().length);
     b.put(s.getBytes());
-    recordSystemCall(dataId);
+    recordSystemCall(dataId, tracer);
     recordExternalData(b);
   }
 
@@ -115,10 +118,10 @@ public class ActorExecutionTrace {
     TracingActor currentActor;
 
     @Override
-    protected void swapBufferWhenNotEnoughSpace() {
+    protected void swapBufferWhenNotEnoughSpace(final TraceActorContext tracer) {
       boolean didSwap = swapStorage();
       assert didSwap;
-      recordActorContextWithoutBufferCheck(currentActor);
+      tracer.execute(currentActor);
     }
 
     static int getUsedBytes(final int id) {
@@ -134,38 +137,14 @@ public class ActorExecutionTrace {
       return 3;
     }
 
-    public void recordActorContext(final TracingActor actor) {
-      ensureSufficientSpace(7);
+    public void recordActorContext(final TracingActor actor, final TraceActorContext tracer) {
+      ensureSufficientSpace(7, tracer);
       currentActor = actor;
-      recordActorContextWithoutBufferCheck(actor);
+      tracer.execute(actor);
     }
 
-    private void recordActorContextWithoutBufferCheck(final TracingActor actor) {
-      int id = actor.getActorId();
-
-      if (VmSettings.TRACE_SMALL_IDS) {
-        int usedBytes = getUsedBytes(id);
-        storage.putByteShort((byte) (ACTOR_CONTEXT | (usedBytes << 4)), actor.getOrdering());
-        writeId(usedBytes, id);
-      } else {
-        storage.putByteShortInt(
-            (byte) (ACTOR_CONTEXT | (3 << 4)), actor.getOrdering(), id);
-      }
-    }
-
-    public void recordActorCreation(final int childId) {
-      ensureSufficientSpace(5);
-      if (VmSettings.TRACE_SMALL_IDS) {
-        int usedBytes = getUsedBytes(childId);
-        storage.put((byte) (ACTOR_CREATION | (usedBytes << 4)));
-        writeId(usedBytes, childId);
-      } else {
-        storage.putByteInt((byte) (ACTOR_CREATION | (3 << 4)), (short) childId);
-      }
-    }
-
-    public void recordMessage(final int senderId) {
-      ensureSufficientSpace(5);
+    public void recordMessage(final int senderId, final TraceActorContext tracer) {
+      ensureSufficientSpace(5, tracer);
       if (VmSettings.TRACE_SMALL_IDS) {
         int usedBytes = getUsedBytes(senderId);
         storage.put((byte) (MESSAGE | (usedBytes << 4)));
@@ -175,8 +154,9 @@ public class ActorExecutionTrace {
       }
     }
 
-    public void recordPromiseMessage(final int senderId, final int resolverId) {
-      ensureSufficientSpace(9);
+    public void recordPromiseMessage(final int senderId, final int resolverId,
+        final TraceActorContext tracer) {
+      ensureSufficientSpace(9, tracer);
       int usedBytes = Math.max(getUsedBytes(resolverId), getUsedBytes(senderId));
 
       if (VmSettings.TRACE_SMALL_IDS) {
@@ -189,8 +169,8 @@ public class ActorExecutionTrace {
     }
 
     public void recordExternalMessage(final int senderId, final short method,
-        final int dataId) {
-      ensureSufficientSpace(11);
+        final int dataId, final TraceActorContext tracer) {
+      ensureSufficientSpace(11, tracer);
 
       if (VmSettings.TRACE_SMALL_IDS) {
         int usedBytes = getUsedBytes(senderId);
@@ -203,8 +183,8 @@ public class ActorExecutionTrace {
     }
 
     public void recordExternalPromiseMessage(final int senderId, final int resolverId,
-        final short method, final int dataId) {
-      ensureSufficientSpace(15);
+        final short method, final int dataId, final TraceActorContext tracer) {
+      ensureSufficientSpace(15, tracer);
 
       if (VmSettings.TRACE_SMALL_IDS) {
         int usedBytes = Math.max(getUsedBytes(resolverId), getUsedBytes(senderId));
@@ -220,8 +200,8 @@ public class ActorExecutionTrace {
       storage.putShortInt(method, senderId);
     }
 
-    public void recordSystemCall(final int dataId) {
-      ensureSufficientSpace(5);
+    public void recordSystemCall(final int dataId, final TraceActorContext tracer) {
+      ensureSufficientSpace(5, tracer);
       storage.putByteInt(SYSTEM_CALL, dataId);
     }
 

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -149,8 +149,8 @@ public class ActorExecutionTrace {
         storage.putShort(actor.getOrdering());
         writeId(usedBytes, id);
       } else {
-      storage.putByteShortShort(
-          (byte) (ACTOR_CONTEXT | (usedBytes << 4)), actor.getOrdering(), (short) id);
+        storage.putByteShortInt(
+            (byte) (ACTOR_CONTEXT | (3 << 4)), actor.getOrdering(), id);
       }
     }
 
@@ -161,7 +161,7 @@ public class ActorExecutionTrace {
         storage.put((byte) (ACTOR_CREATION | (usedBytes << 4)));
         writeId(usedBytes, childId);
       } else {
-      storage.putByteShort((byte) (ACTOR_CREATION | (usedBytes << 4)), (short) childId);
+        storage.putByteInt((byte) (ACTOR_CREATION | (3 << 4)), (short) childId);
       }
     }
 
@@ -172,8 +172,7 @@ public class ActorExecutionTrace {
         storage.put((byte) (MESSAGE | (usedBytes << 4)));
         writeId(usedBytes, senderId);
       } else {
-        storage.put((byte) (MESSAGE | (3 << 4)));
-        storage.putInt(senderId);
+        storage.putByteInt((byte) (MESSAGE | (3 << 4)), senderId);
       }
     }
 
@@ -186,9 +185,7 @@ public class ActorExecutionTrace {
         writeId(usedBytes, senderId);
         writeId(usedBytes, resolverId);
       } else {
-        storage.put((byte) (PROMISE_MESSAGE | (3 << 4)));
-        storage.putInt(senderId);
-        storage.putInt(resolverId);
+        storage.putByteIntInt((byte) (PROMISE_MESSAGE | (3 << 4)), senderId, resolverId);
       }
     }
 
@@ -201,12 +198,10 @@ public class ActorExecutionTrace {
         storage.put((byte) (EXTERNAL_BIT | MESSAGE | (usedBytes << 4)));
         writeId(usedBytes, senderId);
       } else {
-        storage.put((byte) (EXTERNAL_BIT | MESSAGE | (3 << 4)));
-        storage.putInt(senderId);
+        storage.putByteInt((byte) (EXTERNAL_BIT | MESSAGE | (3 << 4)), senderId);
       }
       storage.putShort(method);
       storage.putInt(senderId);
-
     }
 
     public void recordExternalPromiseMessage(final int senderId, final int resolverId,
@@ -220,9 +215,8 @@ public class ActorExecutionTrace {
         writeId(usedBytes, senderId);
         writeId(usedBytes, resolverId);
       } else {
-        storage.put((byte) (EXTERNAL_BIT | PROMISE_MESSAGE | (3 << 4)));
-        storage.putInt(senderId);
-        storage.putInt(resolverId);
+        storage.putByteIntInt((byte) (EXTERNAL_BIT | PROMISE_MESSAGE | (3 << 4)), senderId,
+            resolverId);
       }
 
       storage.putShort(method);
@@ -231,8 +225,7 @@ public class ActorExecutionTrace {
 
     public void recordSystemCall(final int dataId) {
       ensureSufficientSpace(5);
-      storage.put(SYSTEM_CALL);
-      storage.putInt(dataId);
+      storage.putByteInt(SYSTEM_CALL, dataId);
     }
 
     private void writeId(final int usedBytes, final int id) {
@@ -244,8 +237,7 @@ public class ActorExecutionTrace {
           storage.putShort((short) id);
           break;
         case 2:
-          storage.put((byte) (id >> 16));
-          storage.putShort((short) id);
+          storage.putByteShort((byte) (id >> 16), (short) id);
           break;
         case 3:
           storage.putInt(id);

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -1,6 +1,5 @@
 package tools.concurrency;
 
-import som.interpreter.actors.Actor;
 import som.interpreter.actors.EventualMessage;
 import som.interpreter.actors.EventualMessage.ExternalMessage;
 import som.interpreter.actors.EventualMessage.PromiseMessage;
@@ -25,7 +24,7 @@ public class ActorExecutionTrace {
     return (TracingActivityThread) current;
   }
 
-  public static void recordActorContext(final Actor actor) {
+  public static void recordActorContext(final TracingActor actor) {
     TracingActivityThread t = getThread();
     ((ActorTraceBuffer) t.getBuffer()).recordActorContext(actor);
   }
@@ -113,7 +112,7 @@ public class ActorExecutionTrace {
   }
 
   public static class ActorTraceBuffer extends TraceBuffer {
-    Actor currentActor;
+    TracingActor currentActor;
 
     @Override
     protected void swapBufferWhenNotEnoughSpace() {
@@ -135,12 +134,12 @@ public class ActorExecutionTrace {
       return 3;
     }
 
-    public void recordActorContext(final Actor actor) {
+    public void recordActorContext(final TracingActor actor) {
       ensureSufficientSpace(7);
       recordActorContextWithoutBufferCheck(actor);
     }
 
-    private void recordActorContextWithoutBufferCheck(final Actor actor) {
+    private void recordActorContextWithoutBufferCheck(final TracingActor actor) {
       currentActor = actor;
       int id = actor.getActorId();
 

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -145,8 +145,7 @@ public class ActorExecutionTrace {
 
       if (VmSettings.TRACE_SMALL_IDS) {
         int usedBytes = getUsedBytes(id);
-        storage.put((byte) (ACTOR_CONTEXT | (usedBytes << 4)));
-        storage.putShort(actor.getOrdering());
+        storage.putByteShort((byte) (ACTOR_CONTEXT | (usedBytes << 4)), actor.getOrdering());
         writeId(usedBytes, id);
       } else {
         storage.putByteShortInt(
@@ -200,8 +199,7 @@ public class ActorExecutionTrace {
       } else {
         storage.putByteInt((byte) (EXTERNAL_BIT | MESSAGE | (3 << 4)), senderId);
       }
-      storage.putShort(method);
-      storage.putInt(senderId);
+      storage.putShortInt(method, senderId);
     }
 
     public void recordExternalPromiseMessage(final int senderId, final int resolverId,
@@ -219,8 +217,7 @@ public class ActorExecutionTrace {
             resolverId);
       }
 
-      storage.putShort(method);
-      storage.putInt(senderId);
+      storage.putShortInt(method, senderId);
     }
 
     public void recordSystemCall(final int dataId) {

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -1,7 +1,5 @@
 package tools.concurrency;
 
-import java.nio.ByteBuffer;
-
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
 import som.interpreter.actors.Actor;

--- a/src/tools/concurrency/ActorExecutionTrace.java
+++ b/src/tools/concurrency/ActorExecutionTrace.java
@@ -31,11 +31,6 @@ public class ActorExecutionTrace {
     ((ActorTraceBuffer) t.getBuffer()).recordActorContext(actor, tracer);
   }
 
-  public static void recordActorCreation(final int childId) {
-    TracingActivityThread t = getThread();
-    ((ActorTraceBuffer) t.getBuffer()).recordActorCreation(childId);
-  }
-
   public static void recordMessage(final EventualMessage msg, final TraceActorContext tracer) {
     TracingActivityThread t = getThread();
     ActorTraceBuffer atb = ((ActorTraceBuffer) t.getBuffer());

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -48,11 +48,6 @@ public final class ByteBuffer {
     return this;
   }
 
-  public ByteBuffer rewind() {
-    position = 0;
-    return this;
-  }
-
   public int remaining() {
     return buffer.length - position;
   }

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -211,6 +211,21 @@ public final class ByteBuffer {
     // _put(bi + 4, int0(b));
   }
 
+  public void putByteShortByte(final byte a, final short b, final byte c) {
+    int bi = nextPutIndex(1 + 2 + 1);
+    _put(bi, a);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
+    _put(bi + 3, c);
+  }
+
+  public void putByteShortByteShort(final byte a, final short b, final byte c, final short d) {
+    int bi = nextPutIndex(1 + 2 + 1 + 2);
+    _put(bi, a);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
+    _put(bi + 3, c);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 4, d);
+  }
+
   public void putByteShortShort(final byte a, final short b, final short c) {
     int bi = nextPutIndex(1 + 2 + 2);
     _put(bi, a);

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -72,10 +72,6 @@ public final class ByteBuffer {
     return p;
   }
 
-  private void _put(final int i, final byte b) {
-    unsafe.putByte(buffer, byteArrBaseOffset + i, b);
-  }
-
   public ByteBuffer putShort(final short x) {
     int bi = nextPutIndex(2);
     unsafe.putShort(buffer, byteArrBaseOffset + bi, x);
@@ -134,16 +130,16 @@ public final class ByteBuffer {
 
   public void putByteByteShort(final byte a, final byte b, final short c) {
     int bi = nextPutIndex(1 + 2);
-    _put(bi, a);
-    _put(bi + 1, b);
+    putByteAt(bi, a);
+    putByteAt(bi + 1, b);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 2, b);
   }
 
   public void putByteByteShortShortInt(final byte a, final byte b, final short c,
       final short d, final int e) {
     int bi = nextPutIndex(1 + 1 + 2 + 2 + 4);
-    _put(bi, a);
-    _put(bi + 1, b);
+    putByteAt(bi, a);
+    putByteAt(bi + 1, b);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 2, b);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 4, b);
     unsafe.putInt(buffer, byteArrBaseOffset + bi + 6, e);
@@ -151,18 +147,18 @@ public final class ByteBuffer {
 
   public void putByteByteShortInt(final byte a, final byte b, final short c, final int d) {
     int bi = nextPutIndex(1 + 1 + 2 + 4);
-    _put(bi, a);
-    _put(bi + 1, b);
+    putByteAt(bi, a);
+    putByteAt(bi + 1, b);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 2, b);
     unsafe.putInt(buffer, byteArrBaseOffset + bi + 4, b);
   }
 
   public void putByteShort(final byte a, final short b) {
     int bi = nextPutIndex(1 + 2);
-    _put(bi, a);
+    putByteAt(bi, a);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
-    // _put(bi + 1, short1(b));
-    // _put(bi + 2, short0(b));
+    // putByteAt(bi + 1, short1(b));
+    // putByteAt(bi + 2, short0(b));
   }
 
   public void putByteShortAt(final int idx, final byte a, final short b) {
@@ -172,22 +168,22 @@ public final class ByteBuffer {
 
   public void putByteShortByte(final byte a, final short b, final byte c) {
     int bi = nextPutIndex(1 + 2 + 1);
-    _put(bi, a);
+    putByteAt(bi, a);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
-    _put(bi + 3, c);
+    putByteAt(bi + 3, c);
   }
 
   public void putByteShortByteShort(final byte a, final short b, final byte c, final short d) {
     int bi = nextPutIndex(1 + 2 + 1 + 2);
-    _put(bi, a);
+    putByteAt(bi, a);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
-    _put(bi + 3, c);
+    putByteAt(bi + 3, c);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 4, d);
   }
 
   public void putByteShortShortInt(final byte a, final short b, final short c, final int d) {
     int bi = nextPutIndex(1 + 2 + 2 + 4);
-    _put(bi, a);
+    putByteAt(bi, a);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 3, c);
     unsafe.putInt(buffer, byteArrBaseOffset + bi + 5, d);
@@ -195,38 +191,38 @@ public final class ByteBuffer {
 
   public void putByteShortShort(final byte a, final short b, final short c) {
     int bi = nextPutIndex(1 + 2 + 2);
-    _put(bi, a);
+    putByteAt(bi, a);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
-    // _put(bi + 1, short1(b));
-    // _put(bi + 2, short0(b));
+    // putByteAt(bi + 1, short1(b));
+    // putByteAt(bi + 2, short0(b));
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 3, c);
-    // _put(bi + 3, short1(c));
-    // _put(bi + 4, short0(c));
+    // putByteAt(bi + 3, short1(c));
+    // putByteAt(bi + 4, short0(c));
   }
 
   public void putByteShortInt(final byte a, final short b, final int c) {
     int bi = nextPutIndex(1 + 2 + 4);
-    _put(bi, a);
+    putByteAt(bi, a);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
 
-    // _put(bi + 1, short1(b));
-    // _put(bi + 2, short0(b));
+    // putByteAt(bi + 1, short1(b));
+    // putByteAt(bi + 2, short0(b));
     unsafe.putInt(buffer, byteArrBaseOffset + bi + 3, c);
-    // _put(bi + 3, int3(c));
-    // _put(bi + 4, int2(c));
-    // _put(bi + 5, int1(c));
-    // _put(bi + 6, int0(c));
+    // putByteAt(bi + 3, int3(c));
+    // putByteAt(bi + 4, int2(c));
+    // putByteAt(bi + 5, int1(c));
+    // putByteAt(bi + 6, int0(c));
   }
 
   public void putByteInt(final byte a, final int b) {
     int bi = nextPutIndex(1 + 4);
-    _put(bi, a);
+    putByteAt(bi, a);
     unsafe.putInt(buffer, byteArrBaseOffset + bi + 1, b);
   }
 
   public void putByteIntShortInt(final byte a, final int b, final short c, final int d) {
     int bi = nextPutIndex(1 + 4 + 2 + 4);
-    _put(bi, a);
+    putByteAt(bi, a);
 
     unsafe.putInt(buffer, byteArrBaseOffset + bi + 1, b);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 5, c);
@@ -235,17 +231,17 @@ public final class ByteBuffer {
 
   public void putByteIntInt(final byte a, final int b, final int c) {
     int bi = nextPutIndex(1 + 4 + 4);
-    _put(bi, a);
+    putByteAt(bi, a);
     unsafe.putInt(buffer, byteArrBaseOffset + bi + 1, b);
-    // _put(bi + 1, int3(b));
-    // _put(bi + 2, int2(b));
-    // _put(bi + 3, int1(b));
-    // _put(bi + 4, int0(b));
+    // putByteAt(bi + 1, int3(b));
+    // putByteAt(bi + 2, int2(b));
+    // putByteAt(bi + 3, int1(b));
+    // putByteAt(bi + 4, int0(b));
     unsafe.putInt(buffer, byteArrBaseOffset + bi + 5, c);
-    // _put(bi + 5, int3(c));
-    // _put(bi + 6, int2(c));
-    // _put(bi + 7, int1(c));
-    // _put(bi + 8, int0(c));
+    // putByteAt(bi + 5, int3(c));
+    // putByteAt(bi + 6, int2(c));
+    // putByteAt(bi + 7, int1(c));
+    // putByteAt(bi + 8, int0(c));
   }
 
   public void putShortInt(final short a, final int b) {

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -185,6 +185,13 @@ public final class ByteBuffer {
     return this;
   }
 
+  public void putByteByteShort(final byte a, final byte b, final short c) {
+    int bi = nextPutIndex(1 + 2);
+    _put(bi, a);
+    _put(bi + 1, b);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 2, b);
+  }
+
   public void putByteShort(final byte a, final short b) {
     int bi = nextPutIndex(1 + 2);
     _put(bi, a);

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -76,80 +76,16 @@ public final class ByteBuffer {
     unsafe.putByte(buffer, byteArrBaseOffset + i, b);
   }
 
-  private static byte short1(final short x) {
-    return (byte) (x >> 8);
-  }
-
-  private static byte short0(final short x) {
-    return (byte) (x);
-  }
-
-  private static byte long7(final long x) {
-    return (byte) (x >> 56);
-  }
-
-  private static byte long6(final long x) {
-    return (byte) (x >> 48);
-  }
-
-  private static byte long5(final long x) {
-    return (byte) (x >> 40);
-  }
-
-  private static byte long4(final long x) {
-    return (byte) (x >> 32);
-  }
-
-  private static byte long3(final long x) {
-    return (byte) (x >> 24);
-  }
-
-  private static byte long2(final long x) {
-    return (byte) (x >> 16);
-  }
-
-  private static byte long1(final long x) {
-    return (byte) (x >> 8);
-  }
-
-  private static byte long0(final long x) {
-    return (byte) (x);
-  }
-
-  private static byte int3(final int x) {
-    return (byte) (x >> 24);
-  }
-
-  private static byte int2(final int x) {
-    return (byte) (x >> 16);
-  }
-
-  private static byte int1(final int x) {
-    return (byte) (x >> 8);
-  }
-
-  private static byte int0(final int x) {
-    return (byte) (x);
-  }
-
   public ByteBuffer putShort(final short x) {
     int bi = nextPutIndex(2);
-    _put(bi, short1(x));
-    _put(bi + 1, short0(x));
+    unsafe.putShort(buffer, byteArrBaseOffset + bi, x);
 
     return this;
   }
 
   public ByteBuffer putLong(final long x) {
     int bi = nextPutIndex(8);
-    _put(bi, long7(x));
-    _put(bi + 1, long6(x));
-    _put(bi + 2, long5(x));
-    _put(bi + 3, long4(x));
-    _put(bi + 4, long3(x));
-    _put(bi + 5, long2(x));
-    _put(bi + 6, long1(x));
-    _put(bi + 7, long0(x));
+    unsafe.putLong(buffer, byteArrBaseOffset + bi, x);
 
     return this;
   }
@@ -161,10 +97,9 @@ public final class ByteBuffer {
 
   public ByteBuffer putInt(final int x) {
     int bi = nextPutIndex(4);
-    _put(bi, int3(x));
-    _put(bi + 1, int2(x));
-    _put(bi + 2, int1(x));
-    _put(bi + 3, int0(x));
+    unsafe.putInt(buffer, byteArrBaseOffset + bi, x);
+
+    return this;
 
     return this;
   }

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -83,6 +83,11 @@ public final class ByteBuffer {
     return this;
   }
 
+  public ByteBuffer putShortAt(final int idx, final short x) {
+    unsafe.putShort(buffer, byteArrBaseOffset + idx, x);
+    return this;
+  }
+
   public ByteBuffer putLong(final long x) {
     int bi = nextPutIndex(8);
     unsafe.putLong(buffer, byteArrBaseOffset + bi, x);
@@ -100,13 +105,20 @@ public final class ByteBuffer {
     unsafe.putInt(buffer, byteArrBaseOffset + bi, x);
 
     return this;
+  }
 
+  public ByteBuffer putIntAt(final int idx, final int x) {
+    unsafe.putInt(buffer, byteArrBaseOffset + idx, x);
     return this;
   }
 
   public ByteBuffer put(final byte x) {
     unsafe.putByte(buffer, byteArrBaseOffset + nextPutIndex(), x);
-    // buffer[nextPutIndex()] = x;
+    return this;
+  }
+
+  public ByteBuffer putByteAt(final int idx, final byte x) {
+    unsafe.putByte(buffer, byteArrBaseOffset + idx, x);
     return this;
   }
 
@@ -127,6 +139,24 @@ public final class ByteBuffer {
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 2, b);
   }
 
+  public void putByteByteShortShortInt(final byte a, final byte b, final short c,
+      final short d, final int e) {
+    int bi = nextPutIndex(1 + 1 + 2 + 2 + 4);
+    _put(bi, a);
+    _put(bi + 1, b);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 2, b);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 4, b);
+    unsafe.putInt(buffer, byteArrBaseOffset + bi + 6, e);
+  }
+
+  public void putByteByteShortInt(final byte a, final byte b, final short c, final int d) {
+    int bi = nextPutIndex(1 + 1 + 2 + 4);
+    _put(bi, a);
+    _put(bi + 1, b);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 2, b);
+    unsafe.putInt(buffer, byteArrBaseOffset + bi + 4, b);
+  }
+
   public void putByteShort(final byte a, final short b) {
     int bi = nextPutIndex(1 + 2);
     _put(bi, a);
@@ -135,15 +165,9 @@ public final class ByteBuffer {
     // _put(bi + 2, short0(b));
   }
 
-  public void putByteInt(final byte a, final int b) {
-    int bi = nextPutIndex(1 + 4);
-    _put(bi, a);
-
-    unsafe.putInt(buffer, byteArrBaseOffset + bi + 1, b);
-    // _put(bi + 1, int3(b));
-    // _put(bi + 2, int2(b));
-    // _put(bi + 3, int1(b));
-    // _put(bi + 4, int0(b));
+  public void putByteShortAt(final int idx, final byte a, final short b) {
+    unsafe.putByte(buffer, byteArrBaseOffset + idx, a);
+    unsafe.putShort(buffer, byteArrBaseOffset + idx + 1, b);
   }
 
   public void putByteShortByte(final byte a, final short b, final byte c) {
@@ -159,6 +183,14 @@ public final class ByteBuffer {
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
     _put(bi + 3, c);
     unsafe.putShort(buffer, byteArrBaseOffset + bi + 4, d);
+  }
+
+  public void putByteShortShortInt(final byte a, final short b, final short c, final int d) {
+    int bi = nextPutIndex(1 + 2 + 2 + 4);
+    _put(bi, a);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 1, b);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 3, c);
+    unsafe.putInt(buffer, byteArrBaseOffset + bi + 5, d);
   }
 
   public void putByteShortShort(final byte a, final short b, final short c) {
@@ -184,6 +216,21 @@ public final class ByteBuffer {
     // _put(bi + 4, int2(c));
     // _put(bi + 5, int1(c));
     // _put(bi + 6, int0(c));
+  }
+
+  public void putByteInt(final byte a, final int b) {
+    int bi = nextPutIndex(1 + 4);
+    _put(bi, a);
+    unsafe.putInt(buffer, byteArrBaseOffset + bi + 1, b);
+  }
+
+  public void putByteIntShortInt(final byte a, final int b, final short c, final int d) {
+    int bi = nextPutIndex(1 + 4 + 2 + 4);
+    _put(bi, a);
+
+    unsafe.putInt(buffer, byteArrBaseOffset + bi + 1, b);
+    unsafe.putShort(buffer, byteArrBaseOffset + bi + 5, c);
+    unsafe.putInt(buffer, byteArrBaseOffset + bi + 7, d);
   }
 
   public void putByteIntInt(final byte a, final int b, final int c) {

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -169,4 +169,20 @@ public final class ByteBuffer {
     position += length;
     return this;
   }
+
+  public void putByteShort(final byte a, final short b) {
+    int bi = nextPutIndex(1 + 2);
+    _put(bi, a);
+    _put(bi + 1, short1(b));
+    _put(bi + 2, short0(b));
+  }
+
+  public void putByteShortShort(final byte a, final short b, final short c) {
+    int bi = nextPutIndex(1 + 2 + 2);
+    _put(bi, a);
+    _put(bi + 1, short1(b));
+    _put(bi + 2, short0(b));
+    _put(bi + 3, short1(c));
+    _put(bi + 4, short0(c));
+  }
 }

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -73,7 +73,7 @@ public final class ByteBuffer {
   }
 
   private void _put(final int i, final byte b) {
-    buffer[i] = b;
+    unsafe.putByte(buffer, byteArrBaseOffset + i, b);
   }
 
   private static byte short1(final short x) {
@@ -170,7 +170,8 @@ public final class ByteBuffer {
   }
 
   public ByteBuffer put(final byte x) {
-    buffer[nextPutIndex()] = x;
+    unsafe.putByte(buffer, byteArrBaseOffset + nextPutIndex(), x);
+    // buffer[nextPutIndex()] = x;
     return this;
   }
 

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -177,6 +177,15 @@ public final class ByteBuffer {
     _put(bi + 2, short0(b));
   }
 
+  public void putByteInt(final byte a, final int b) {
+    int bi = nextPutIndex(1 + 4);
+    _put(bi, a);
+    _put(bi + 1, int3(b));
+    _put(bi + 2, int2(b));
+    _put(bi + 3, int1(b));
+    _put(bi + 4, int0(b));
+  }
+
   public void putByteShortShort(final byte a, final short b, final short c) {
     int bi = nextPutIndex(1 + 2 + 2);
     _put(bi, a);
@@ -184,5 +193,29 @@ public final class ByteBuffer {
     _put(bi + 2, short0(b));
     _put(bi + 3, short1(c));
     _put(bi + 4, short0(c));
+  }
+
+  public void putByteShortInt(final byte a, final short b, final int c) {
+    int bi = nextPutIndex(1 + 2 + 4);
+    _put(bi, a);
+    _put(bi + 1, short1(b));
+    _put(bi + 2, short0(b));
+    _put(bi + 3, int3(c));
+    _put(bi + 4, int2(c));
+    _put(bi + 5, int1(c));
+    _put(bi + 6, int0(c));
+  }
+
+  public void putByteIntInt(final byte a, final int b, final int c) {
+    int bi = nextPutIndex(1 + 4 + 4);
+    _put(bi, a);
+    _put(bi + 1, int3(b));
+    _put(bi + 2, int2(b));
+    _put(bi + 3, int1(b));
+    _put(bi + 4, int0(b));
+    _put(bi + 5, int3(c));
+    _put(bi + 6, int2(c));
+    _put(bi + 7, int1(c));
+    _put(bi + 8, int0(c));
   }
 }

--- a/src/tools/concurrency/ByteBuffer.java
+++ b/src/tools/concurrency/ByteBuffer.java
@@ -1,0 +1,205 @@
+package tools.concurrency;
+
+import java.nio.BufferOverflowException;
+
+
+public final class ByteBuffer {
+  public static ByteBuffer allocate(final int capacity) {
+    return new ByteBuffer(capacity);
+  }
+
+  private int position;
+  private int limit;
+  private int capacity;
+
+  private final byte[] buffer;
+
+  private ByteBuffer(final int capacity) {
+    buffer = new byte[capacity];
+    this.capacity = capacity;
+    this.limit = capacity;
+    this.position = 0;
+  }
+
+  public java.nio.ByteBuffer getBuffer() {
+    return java.nio.ByteBuffer.wrap(buffer, 0, limit);
+  }
+
+  public int position() {
+    return position;
+  }
+
+  public ByteBuffer position(final int newPosition) {
+    if ((newPosition > limit) || (newPosition < 0)) {
+      throw new IllegalArgumentException();
+    }
+    position = newPosition;
+    return this;
+  }
+
+  public ByteBuffer rewind() {
+    position = 0;
+    return this;
+  }
+
+  public int remaining() {
+    return limit - position;
+  }
+
+  public ByteBuffer clear() {
+    position = 0;
+    limit = capacity;
+    return this;
+  }
+
+  public ByteBuffer limit(final int newLimit) {
+    if ((newLimit > capacity) || (newLimit < 0)) {
+      throw new IllegalArgumentException();
+    }
+    limit = newLimit;
+    if (position > limit) {
+      position = limit;
+    }
+    return this;
+  }
+
+  private int nextPutIndex() {
+    if (position >= limit) {
+      throw new BufferOverflowException();
+    }
+    return position++;
+  }
+
+  private int nextPutIndex(final int nb) {
+    if (limit - position < nb) {
+      throw new BufferOverflowException();
+    }
+    int p = position;
+    position += nb;
+    return p;
+  }
+
+  private void _put(final int i, final byte b) {
+    buffer[i] = b;
+  }
+
+  private static byte short1(final short x) {
+    return (byte) (x >> 8);
+  }
+
+  private static byte short0(final short x) {
+    return (byte) (x);
+  }
+
+  private static byte long7(final long x) {
+    return (byte) (x >> 56);
+  }
+
+  private static byte long6(final long x) {
+    return (byte) (x >> 48);
+  }
+
+  private static byte long5(final long x) {
+    return (byte) (x >> 40);
+  }
+
+  private static byte long4(final long x) {
+    return (byte) (x >> 32);
+  }
+
+  private static byte long3(final long x) {
+    return (byte) (x >> 24);
+  }
+
+  private static byte long2(final long x) {
+    return (byte) (x >> 16);
+  }
+
+  private static byte long1(final long x) {
+    return (byte) (x >> 8);
+  }
+
+  private static byte long0(final long x) {
+    return (byte) (x);
+  }
+
+  private static byte int3(final int x) {
+    return (byte) (x >> 24);
+  }
+
+  private static byte int2(final int x) {
+    return (byte) (x >> 16);
+  }
+
+  private static byte int1(final int x) {
+    return (byte) (x >> 8);
+  }
+
+  private static byte int0(final int x) {
+    return (byte) (x);
+  }
+
+  public ByteBuffer putShort(final short x) {
+    int bi = nextPutIndex(2);
+    _put(bi, short1(x));
+    _put(bi + 1, short0(x));
+
+    return this;
+  }
+
+  public ByteBuffer putLong(final long x) {
+    int bi = nextPutIndex(8);
+    _put(bi, long7(x));
+    _put(bi + 1, long6(x));
+    _put(bi + 2, long5(x));
+    _put(bi + 3, long4(x));
+    _put(bi + 4, long3(x));
+    _put(bi + 5, long2(x));
+    _put(bi + 6, long1(x));
+    _put(bi + 7, long0(x));
+
+    return this;
+  }
+
+  public ByteBuffer putDouble(final double x) {
+    putLong(Double.doubleToRawLongBits(x));
+    return this;
+  }
+
+  public ByteBuffer putInt(final int x) {
+    int bi = nextPutIndex(4);
+    _put(bi, int3(x));
+    _put(bi + 1, int2(x));
+    _put(bi + 2, int1(x));
+    _put(bi + 3, int0(x));
+
+    return this;
+  }
+
+  public ByteBuffer put(final byte x) {
+    buffer[nextPutIndex()] = x;
+    return this;
+  }
+
+  public ByteBuffer put(final byte[] src) {
+    return put(src, 0, src.length);
+  }
+
+  private static void checkBounds(final int off, final int len, final int size) {
+    if ((off | len | (off + len) | (size - (off + len))) < 0) {
+      throw new IndexOutOfBoundsException();
+    }
+  }
+
+  public ByteBuffer put(final byte[] src, final int offset, final int length) {
+
+    checkBounds(offset, length, src.length);
+    if (length > remaining()) {
+      throw new BufferOverflowException();
+    }
+    System.arraycopy(src, offset, buffer, position(), length);
+    position(position() + length);
+    return this;
+
+  }
+}

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -44,10 +44,11 @@ public abstract class TraceBuffer {
     return true;
   }
 
-  protected final void ensureSufficientSpace(final int requiredSpace) {
+  public final ByteBuffer ensureSufficientSpace(final int requiredSpace) {
     if (storage.remaining() < requiredSpace) {
       swapBufferWhenNotEnoughSpace();
     }
+    return storage;
   }
 
   protected void swapBufferWhenNotEnoughSpace() {

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -2,7 +2,7 @@ package tools.concurrency;
 
 import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
-import tools.concurrency.nodes.TraceActorContext;
+import tools.concurrency.nodes.TraceActorContextNode;
 
 
 public abstract class TraceBuffer {
@@ -46,7 +46,7 @@ public abstract class TraceBuffer {
   }
 
   public final ByteBuffer ensureSufficientSpace(final int requiredSpace,
-      final TraceActorContext tracer) {
+      final TraceActorContextNode tracer) {
     if (storage.remaining() < requiredSpace) {
       swapBufferWhenNotEnoughSpace(tracer);
     }
@@ -57,7 +57,7 @@ public abstract class TraceBuffer {
     return storage;
   }
 
-  protected void swapBufferWhenNotEnoughSpace(final TraceActorContext tracer) {
+  protected void swapBufferWhenNotEnoughSpace(final TraceActorContextNode tracer) {
     swapStorage();
   }
 }

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -2,6 +2,7 @@ package tools.concurrency;
 
 import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
+import tools.concurrency.nodes.TraceActorContext;
 
 
 public abstract class TraceBuffer {
@@ -44,14 +45,19 @@ public abstract class TraceBuffer {
     return true;
   }
 
-  public final ByteBuffer ensureSufficientSpace(final int requiredSpace) {
+  public final ByteBuffer ensureSufficientSpace(final int requiredSpace,
+      final TraceActorContext tracer) {
     if (storage.remaining() < requiredSpace) {
-      swapBufferWhenNotEnoughSpace();
+      swapBufferWhenNotEnoughSpace(tracer);
     }
     return storage;
   }
 
-  protected void swapBufferWhenNotEnoughSpace() {
+  public final ByteBuffer getStorage() {
+    return storage;
+  }
+
+  protected void swapBufferWhenNotEnoughSpace(final TraceActorContext tracer) {
     swapStorage();
   }
 }

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -7,10 +7,10 @@ import tools.concurrency.nodes.TraceActorContextNode;
 
 public abstract class TraceBuffer {
 
-  public static TraceBuffer create() {
+  public static TraceBuffer create(final long implThreadId) {
     assert VmSettings.ACTOR_TRACING || VmSettings.MEDEOR_TRACING;
     if (VmSettings.TRUFFLE_DEBUGGER_ENABLED) {
-      return MedeorTrace.MedeorTraceBuffer.create();
+      return MedeorTrace.MedeorTraceBuffer.create(implThreadId);
     } else {
       return new ActorTraceBuffer();
     }

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -39,7 +39,7 @@ public abstract class TraceBuffer {
     return storage.remaining() == 0;
   }
 
-  boolean swapStorage() {
+  public boolean swapStorage() {
     TracingBackend.returnBuffer(storage);
     retrieveBuffer();
     return true;

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -1,8 +1,5 @@
 package tools.concurrency;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
 import som.vm.VmSettings;
@@ -28,7 +25,6 @@ public abstract class TraceBuffer {
 
   public void retrieveBuffer() {
     this.storage = TracingBackend.getEmptyBuffer();
-    assert storage.order() == ByteOrder.BIG_ENDIAN;
   }
 
   public void returnBuffer() {

--- a/src/tools/concurrency/TraceBuffer.java
+++ b/src/tools/concurrency/TraceBuffer.java
@@ -1,7 +1,5 @@
 package tools.concurrency;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-
 import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
 
@@ -46,14 +44,13 @@ public abstract class TraceBuffer {
     return true;
   }
 
-  @TruffleBoundary
-  protected boolean ensureSufficientSpace(final int requiredSpace) {
+  protected final void ensureSufficientSpace(final int requiredSpace) {
     if (storage.remaining() < requiredSpace) {
-      boolean didSwap = swapStorage();
-      assert didSwap;
-      return didSwap;
+      swapBufferWhenNotEnoughSpace();
     }
-    return false;
   }
 
+  protected void swapBufferWhenNotEnoughSpace() {
+    swapStorage();
+  }
 }

--- a/src/tools/concurrency/TraceParser.java
+++ b/src/tools/concurrency/TraceParser.java
@@ -97,7 +97,6 @@ public final class TraceParser {
           b.clear();
           channel.read(b);
           b.flip();
-          // System.out.println("swapping");
         } else if (b.remaining() < 20) {
           b.compact();
           channel.read(b);
@@ -150,8 +149,6 @@ public final class TraceParser {
             if (!actors.containsKey(currentActor)) {
               actors.put(currentActor, new ActorNode(currentActor));
             }
-
-            // System.out.println("" + currentActor + " : " + ordering);
 
             contextMessages = null;
             assert b.position() == start + (numbytes + 4);
@@ -220,8 +217,8 @@ public final class TraceParser {
     int                                        mailboxNo;
     boolean                                    sorted           = false;
     ArrayList<ActorNode>                       children;
-    HashMap<Integer, ArrayList<MessageRecord>> bucket1         = new HashMap<>();
-    HashMap<Integer, ArrayList<MessageRecord>> bucket2         = new HashMap<>();
+    HashMap<Integer, ArrayList<MessageRecord>> bucket1          = new HashMap<>();
+    HashMap<Integer, ArrayList<MessageRecord>> bucket2          = new HashMap<>();
     Queue<MessageRecord>                       expectedMessages = new java.util.LinkedList<>();
 
     ActorNode(final long actorId) {

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -29,6 +29,8 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread {
 
   protected ConcurrentEntityScope topEntity;
 
+  public volatile boolean swapTracingBuffer = false;
+
   private static class ConcurrentEntityScope {
     private final EntityType            type;
     private final ConcurrentEntityScope next;

--- a/src/tools/concurrency/TracingActivityThread.java
+++ b/src/tools/concurrency/TracingActivityThread.java
@@ -42,8 +42,8 @@ public abstract class TracingActivityThread extends ForkJoinWorkerThread {
   public TracingActivityThread(final ForkJoinPool pool) {
     super(pool);
     if (VmSettings.ACTOR_TRACING) {
-      traceBuffer = TraceBuffer.create();
       threadId = threadIdGen.getAndIncrement();
+      traceBuffer = TraceBuffer.create(threadId);
       nextEntityId = 1 + (threadId << TraceData.ENTITY_ID_BITS);
     } else {
       threadId = 0;

--- a/src/tools/concurrency/TracingActors.java
+++ b/src/tools/concurrency/TracingActors.java
@@ -47,17 +47,14 @@ public class TracingActors {
       return actorId;
     }
 
-    @Override
     public final int getActorId() {
       return actorId;
     }
 
-    @Override
     public short getOrdering() {
       return ordering;
     }
 
-    @Override
     public synchronized int getDataId() {
       return nextDataID++;
     }

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -157,9 +157,6 @@ public class TracingBackend {
       return;
     }
 
-    b.limit(b.position());
-    b.rewind();
-
     returnBufferGlobally(b);
   }
 
@@ -206,9 +203,6 @@ public class TracingBackend {
     if (b == null) {
       return;
     }
-
-    b.limit(b.position());
-    b.rewind();
 
     synchronized (externalData) {
       externalData.add(b);
@@ -286,7 +280,8 @@ public class TracingBackend {
             synchronized (externalData) {
               while (!externalData.isEmpty()) {
                 // TODO: the buffer gets lost here, is this on purpose?
-                edfos.getChannel().write(externalData.removeFirst().getBuffer());
+                edfos.getChannel()
+                     .write(externalData.removeFirst().getReadingFromStartBuffer());
                 edfos.flush();
               }
             }
@@ -304,7 +299,7 @@ public class TracingBackend {
               TracingBackend.symbolsToWrite.clear();
             }
 
-            fos.getChannel().write(b.getBuffer());
+            fos.getChannel().write(b.getReadingFromStartBuffer());
             fos.flush();
             b.rewind();
 

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -11,7 +11,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
 import java.lang.management.MemoryUsage;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -282,7 +281,8 @@ public class TracingBackend {
 
             synchronized (externalData) {
               while (!externalData.isEmpty()) {
-                edfos.getChannel().write(externalData.removeFirst());
+                // TODO: the buffer gets lost here, is this on purpose?
+                edfos.getChannel().write(externalData.removeFirst().getBuffer());
                 edfos.flush();
               }
             }
@@ -300,7 +300,7 @@ public class TracingBackend {
               TracingBackend.symbolsToWrite.clear();
             }
 
-            fos.getChannel().write(b);
+            fos.getChannel().write(b.getBuffer());
             fos.flush();
             b.rewind();
 

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -251,7 +251,7 @@ public class TracingBackend {
             FileOutputStream edfos = new FileOutputStream(edf);
             BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(sfos))) {
 
-          while (cont || TracingBackend.fullBuffers.size() > 0) {
+          while (cont || !TracingBackend.fullBuffers.isEmpty()) {
             ByteBuffer b;
 
             try {
@@ -314,7 +314,7 @@ public class TracingBackend {
           throw new RuntimeException(e);
         }
       } else {
-        while (cont || TracingBackend.fullBuffers.size() > 0) {
+        while (cont || !TracingBackend.fullBuffers.isEmpty()) {
           ByteBuffer b;
 
           try {

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -152,7 +152,6 @@ public class TracingBackend {
     }
   }
 
-  @TruffleBoundary
   static void returnBuffer(final ByteBuffer b) {
     if (b == null) {
       return;
@@ -161,6 +160,11 @@ public class TracingBackend {
     b.limit(b.position());
     b.rewind();
 
+    returnBufferGlobally(b);
+  }
+
+  @TruffleBoundary
+  private static void returnBufferGlobally(final ByteBuffer b) {
     synchronized (fullBuffers) {
       fullBuffers.add(b);
     }

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -267,7 +267,7 @@ public class TracingBackend {
               continue;
             }
 
-            if (b.remaining() <= Implementation.IMPL_THREAD.getSize() +
+            if (b.position() <= Implementation.IMPL_THREAD.getSize() +
                 Implementation.IMPL_CURRENT_ACTIVITY.getSize()) {
               // Ignore buffers that only contain the thread index
               b.clear();
@@ -333,7 +333,7 @@ public class TracingBackend {
             TracingBackend.symbolsToWrite.clear();
           }
 
-          if (b.remaining() > (Implementation.IMPL_THREAD.getSize() +
+          if (b.position() > (Implementation.IMPL_THREAD.getSize() +
               Implementation.IMPL_CURRENT_ACTIVITY.getSize()) && front != null) {
             front.sendTracingData(b);
           }

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -162,9 +162,7 @@ public class TracingBackend {
 
   @TruffleBoundary
   private static void returnBufferGlobally(final ByteBuffer b) {
-    synchronized (fullBuffers) {
-      fullBuffers.add(b);
-    }
+    fullBuffers.offer(b);
   }
 
   private static HashSet<TracingActivityThread> tracingThreads = new HashSet<>();

--- a/src/tools/concurrency/nodes/RecordIdIdNode.java
+++ b/src/tools/concurrency/nodes/RecordIdIdNode.java
@@ -1,0 +1,67 @@
+package tools.concurrency.nodes;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+
+import som.vm.VmSettings;
+import tools.concurrency.ByteBuffer;
+
+
+public abstract class RecordIdIdNode extends Node {
+  private static final int BYTE_LEN       = 1;
+  private static final int SHORT_LEN      = 2;
+  private static final int THREE_BYTE_LEN = 3;
+  private static final int INT_LEN        = 4;
+
+  public abstract int execute(ByteBuffer storage, int idx, int id1, int id2);
+
+  protected static boolean smallIds() {
+    return VmSettings.TRACE_SMALL_IDS;
+  }
+
+  protected static boolean byteId(final int id1, final int id2) {
+    return (id1 & id2 & 0xFFFFFF00) == 0;
+  }
+
+  protected static boolean shortId(final int id1, final int id2) {
+    return (id1 & id2 & 0xFFFF0000) == 0;
+  }
+
+  protected static boolean threeByteId(final int id1, final int id2) {
+    return (id1 & id2 & 0xFF000000) == 0;
+  }
+
+  @Specialization(guards = {"smallIds()", "byteId(id1, id2)"})
+  public int traceByteId(final ByteBuffer storage, final int idx, final int id1,
+      final int id2) {
+    storage.putByteAt(idx, (byte) id1);
+    storage.putByteAt(idx + 1, (byte) id2);
+    return BYTE_LEN;
+  }
+
+  @Specialization(guards = {"smallIds()", "shortId(id1, id2)"},
+      replaces = "traceByteId")
+  public int traceShortId(final ByteBuffer storage, final int idx, final int id1,
+      final int id2) {
+    storage.putShortAt(idx, (short) id1);
+    storage.putShortAt(idx + 2, (short) id2);
+    return SHORT_LEN;
+  }
+
+  @Specialization(guards = {"smallIds()", "threeByteId(id1, id2)"},
+      replaces = {"traceShortId", "traceByteId"})
+  public int traceThreeByteId(final ByteBuffer storage, final int idx, final int id1,
+      final int id2) {
+    storage.putByteShortAt(idx, (byte) (id1 >> 16), (short) id1);
+    storage.putByteShortAt(idx + 3, (byte) (id2 >> 16), (short) id2);
+    return THREE_BYTE_LEN;
+  }
+
+  @Specialization(replaces = {"traceShortId", "traceByteId", "traceThreeByteId"})
+  public int traceStandardId(final ByteBuffer storage, final int idx, final int id1,
+      final int id2) {
+    storage.putIntAt(idx, id1);
+    storage.putIntAt(idx + 4, id2);
+    return INT_LEN;
+  }
+}

--- a/src/tools/concurrency/nodes/RecordIdNode.java
+++ b/src/tools/concurrency/nodes/RecordIdNode.java
@@ -1,0 +1,59 @@
+package tools.concurrency.nodes;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+
+import som.vm.VmSettings;
+import tools.concurrency.ByteBuffer;
+
+
+public abstract class RecordIdNode extends Node {
+  private static final int BYTE_LEN       = 1;
+  private static final int SHORT_LEN      = 2;
+  private static final int THREE_BYTE_LEN = 3;
+  private static final int INT_LEN        = 4;
+
+  public abstract int execute(ByteBuffer storage, int idx, int id);
+
+  protected static boolean smallIds() {
+    return VmSettings.TRACE_SMALL_IDS;
+  }
+
+  protected static boolean byteId(final int id) {
+    return (id & 0xFFFFFF00) == 0;
+  }
+
+  protected static boolean shortId(final int id) {
+    return (id & 0xFFFF0000) == 0;
+  }
+
+  protected static boolean threeByteId(final int id) {
+    return (id & 0xFF000000) == 0;
+  }
+
+  @Specialization(guards = {"smallIds()", "byteId(id)"})
+  public int traceByteId(final ByteBuffer storage, final int idx, final int id) {
+    storage.putByteAt(idx, (byte) id);
+    return BYTE_LEN;
+  }
+
+  @Specialization(guards = {"smallIds()", "shortId(id)"},
+      replaces = "traceByteId")
+  public int traceShortId(final ByteBuffer storage, final int idx, final int id) {
+    storage.putShortAt(idx, (short) id);
+    return SHORT_LEN;
+  }
+
+  @Specialization(guards = {"smallIds()", "threeByteId(id)"},
+      replaces = {"traceShortId", "traceByteId"})
+  public int traceThreeByteId(final ByteBuffer storage, final int idx, final int id) {
+    storage.putByteShortAt(idx, (byte) (id >> 16), (short) id);
+    return THREE_BYTE_LEN;
+  }
+
+  @Specialization(replaces = {"traceShortId", "traceByteId", "traceThreeByteId"})
+  public int traceStandardId(final ByteBuffer storage, final int idx, final int id) {
+    storage.putIntAt(idx, id);
+    return INT_LEN;
+  }
+}

--- a/src/tools/concurrency/nodes/TraceActorContext.java
+++ b/src/tools/concurrency/nodes/TraceActorContext.java
@@ -1,34 +1,14 @@
 package tools.concurrency.nodes;
 
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.nodes.Node;
 
-import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace;
 import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
 import tools.concurrency.ByteBuffer;
-import tools.concurrency.TracingActivityThread;
 import tools.concurrency.TracingActors.TracingActor;
 
 
-public abstract class TraceActorContext extends Node {
-  public abstract void execute(TracingActor actor);
-
-  protected static boolean smallIds() {
-    return VmSettings.TRACE_SMALL_IDS;
-  }
-
-  protected static boolean byteId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFFFFFF00) == 0;
-  }
-
-  protected static boolean shortId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFFFF0000) == 0;
-  }
-
-  protected static boolean threeByteId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFF000000) == 0;
-  }
+public abstract class TraceActorContext extends TraceNode {
 
   @Specialization(guards = {"smallIds()", "byteId(actor)"})
   public static void traceByteId(final TracingActor actor) {
@@ -64,16 +44,5 @@ public abstract class TraceActorContext extends Node {
   private static ByteBuffer getStorage() {
     ActorTraceBuffer buffer = getCurrentBuffer();
     return buffer.getStorage();
-  }
-
-  private static TracingActivityThread getThread() {
-    Thread current = Thread.currentThread();
-    assert current instanceof TracingActivityThread;
-    return (TracingActivityThread) current;
-  }
-
-  private static ActorTraceBuffer getCurrentBuffer() {
-    TracingActivityThread t = getThread();
-    return (ActorTraceBuffer) t.getBuffer();
   }
 }

--- a/src/tools/concurrency/nodes/TraceActorContextNode.java
+++ b/src/tools/concurrency/nodes/TraceActorContextNode.java
@@ -8,7 +8,7 @@ import tools.concurrency.ByteBuffer;
 import tools.concurrency.TracingActors.TracingActor;
 
 
-public abstract class TraceActorContext extends TraceNode {
+public abstract class TraceActorContextNode extends TraceNode {
 
   @Specialization(guards = {"smallIds()", "byteId(actor)"})
   public static void traceByteId(final TracingActor actor) {

--- a/src/tools/concurrency/nodes/TraceActorCreation.java
+++ b/src/tools/concurrency/nodes/TraceActorCreation.java
@@ -1,0 +1,78 @@
+package tools.concurrency.nodes;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.nodes.Node;
+
+import som.vm.VmSettings;
+import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
+import tools.concurrency.ByteBuffer;
+import tools.concurrency.TracingActivityThread;
+import tools.concurrency.TracingActors.TracingActor;
+
+
+public abstract class TraceActorCreation extends Node {
+  public abstract void execute(TracingActor actor);
+
+  protected static boolean smallIds() {
+    return VmSettings.TRACE_SMALL_IDS;
+  }
+
+  protected static boolean byteId(final TracingActor actor) {
+    return (actor.getActorId() & 0xFFFFFF00) == 0;
+  }
+
+  protected static boolean shortId(final TracingActor actor) {
+    return (actor.getActorId() & 0xFFFF0000) == 0;
+  }
+
+  protected static boolean threeByteId(final TracingActor actor) {
+    return (actor.getActorId() & 0xFF000000) == 0;
+  }
+
+  @Specialization(guards = {"smallIds()", "byteId(actor)"})
+  public static void traceByteId(final TracingActor actor) {
+    ByteBuffer storage = getStorage();
+    storage.put((byte) (ActorExecutionTrace.ACTOR_CREATION | (0 << 4)));
+    storage.put((byte) actor.getActorId());
+  }
+
+  @Specialization(guards = {"smallIds()", "shortId(actor)"}, replaces = "traceByteId")
+  public static void traceShortId(final TracingActor actor) {
+    ByteBuffer storage = getStorage();
+    storage.putByteShort((byte) (ActorExecutionTrace.ACTOR_CREATION | (1 << 4)),
+        (short) actor.getActorId());
+  }
+
+  @Specialization(guards = {"smallIds()", "threeByteId(actor)"},
+      replaces = {"traceShortId", "traceByteId"})
+  public static void traceThreeByteId(final TracingActor actor) {
+    ByteBuffer storage = getStorage();
+    int id = actor.getActorId();
+    storage.putByteByteShort((byte) (ActorExecutionTrace.ACTOR_CREATION | (2 << 4)),
+        (byte) (id >> 16), (short) id);
+  }
+
+  @Specialization(replaces = {"traceShortId", "traceByteId", "traceThreeByteId"})
+  public static void traceStandardId(final TracingActor actor) {
+    ByteBuffer storage = getStorage();
+    int id = actor.getActorId();
+    storage.putByteInt((byte) (ActorExecutionTrace.ACTOR_CREATION | (3 << 4)), id);
+  }
+
+  private static ByteBuffer getStorage() {
+    ActorTraceBuffer buffer = getCurrentBuffer();
+    return buffer.ensureSufficientSpace(5);
+  }
+
+  private static TracingActivityThread getThread() {
+    Thread current = Thread.currentThread();
+    assert current instanceof TracingActivityThread;
+    return (TracingActivityThread) current;
+  }
+
+  private static ActorTraceBuffer getCurrentBuffer() {
+    TracingActivityThread t = getThread();
+    return (ActorTraceBuffer) t.getBuffer();
+  }
+}

--- a/src/tools/concurrency/nodes/TraceActorCreation.java
+++ b/src/tools/concurrency/nodes/TraceActorCreation.java
@@ -1,34 +1,14 @@
 package tools.concurrency.nodes;
 
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.nodes.Node;
 
-import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace;
 import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
 import tools.concurrency.ByteBuffer;
-import tools.concurrency.TracingActivityThread;
 import tools.concurrency.TracingActors.TracingActor;
 
 
-public abstract class TraceActorCreation extends Node {
-  public abstract void execute(TracingActor actor);
-
-  protected static boolean smallIds() {
-    return VmSettings.TRACE_SMALL_IDS;
-  }
-
-  protected static boolean byteId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFFFFFF00) == 0;
-  }
-
-  protected static boolean shortId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFFFF0000) == 0;
-  }
-
-  protected static boolean threeByteId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFF000000) == 0;
-  }
+public abstract class TraceActorCreation extends TraceNode {
 
   @Specialization(guards = {"smallIds()", "byteId(actor)"})
   public void traceByteId(final TracingActor actor) {
@@ -65,16 +45,5 @@ public abstract class TraceActorCreation extends Node {
   private ByteBuffer getStorage() {
     ActorTraceBuffer buffer = getCurrentBuffer();
     return buffer.ensureSufficientSpace(5, tracer);
-  }
-
-  private static TracingActivityThread getThread() {
-    Thread current = Thread.currentThread();
-    assert current instanceof TracingActivityThread;
-    return (TracingActivityThread) current;
-  }
-
-  private static ActorTraceBuffer getCurrentBuffer() {
-    TracingActivityThread t = getThread();
-    return (ActorTraceBuffer) t.getBuffer();
   }
 }

--- a/src/tools/concurrency/nodes/TraceActorCreationNode.java
+++ b/src/tools/concurrency/nodes/TraceActorCreationNode.java
@@ -8,7 +8,7 @@ import tools.concurrency.ByteBuffer;
 import tools.concurrency.TracingActors.TracingActor;
 
 
-public abstract class TraceActorCreation extends TraceNode {
+public abstract class TraceActorCreationNode extends TraceNode {
 
   @Specialization(guards = {"smallIds()", "byteId(actor)"})
   public void traceByteId(final TracingActor actor) {
@@ -40,7 +40,7 @@ public abstract class TraceActorCreation extends TraceNode {
     storage.putByteInt((byte) (ActorExecutionTrace.ACTOR_CREATION | (3 << 4)), id);
   }
 
-  @Child TraceActorContext tracer = TraceActorContextNodeGen.create();
+  @Child TraceActorContextNode tracer = TraceActorContextNodeGen.create();
 
   private ByteBuffer getStorage() {
     ActorTraceBuffer buffer = getCurrentBuffer();

--- a/src/tools/concurrency/nodes/TraceMessageNode.java
+++ b/src/tools/concurrency/nodes/TraceMessageNode.java
@@ -44,7 +44,7 @@ public abstract class TraceMessageNode extends TraceNode {
     int idLen = id.execute(storage, pos + 1, ((TracingActor) msg.getSender()).getActorId());
     int idBit = (idLen - 1) << 4;
 
-    storage.put((byte) (ActorExecutionTrace.MESSAGE | idBit));
+    storage.putByteAt(pos, (byte) (ActorExecutionTrace.MESSAGE | idBit));
     storage.position(pos + idLen + 1);
   }
 
@@ -91,7 +91,7 @@ public abstract class TraceMessageNode extends TraceNode {
         ((STracingPromise) msg.getPromise()).getResolvingActor());
     int idBit = (idLen - 1) << 4;
 
-    storage.put((byte) (ActorExecutionTrace.PROMISE_MESSAGE | idBit));
+    storage.putByteAt(pos, (byte) (ActorExecutionTrace.PROMISE_MESSAGE | idBit));
     storage.position(pos + idLen + idLen + 1);
   }
 

--- a/src/tools/concurrency/nodes/TraceMessageNode.java
+++ b/src/tools/concurrency/nodes/TraceMessageNode.java
@@ -1,0 +1,132 @@
+package tools.concurrency.nodes;
+
+import com.oracle.truffle.api.dsl.Specialization;
+
+import som.interpreter.actors.EventualMessage;
+import som.interpreter.actors.EventualMessage.DirectMessage;
+import som.interpreter.actors.EventualMessage.ExternalDirectMessage;
+import som.interpreter.actors.EventualMessage.ExternalPromiseCallbackMessage;
+import som.interpreter.actors.EventualMessage.ExternalPromiseSendMessage;
+import som.interpreter.actors.EventualMessage.PromiseCallbackMessage;
+import som.interpreter.actors.EventualMessage.PromiseMessage;
+import som.interpreter.actors.EventualMessage.PromiseSendMessage;
+import som.interpreter.actors.SPromise.STracingPromise;
+import tools.concurrency.ActorExecutionTrace;
+import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
+import tools.concurrency.ByteBuffer;
+import tools.concurrency.TracingActors.TracingActor;
+
+
+public abstract class TraceMessageNode extends TraceNode {
+
+  private static final int DIRECT_MSG_SIZE      = 5;
+  private static final int PROMISE_MSG_SIZE     = 9;
+  private static final int EXT_DIRECT_MSG_SIZE  = 11;
+  private static final int EXT_PROMISE_MSG_SIZE = 15;
+
+  @Child TraceActorContextNode    tracer = new TraceActorContextNode();
+  @Child protected RecordIdNode   id     = RecordIdNodeGen.create();
+  @Child protected RecordIdIdNode idid   = RecordIdIdNodeGen.create();
+
+  public abstract void execute(EventualMessage msg);
+
+  private ByteBuffer getStorage(final int entrySize) {
+    ActorTraceBuffer buffer = getCurrentBuffer();
+    return buffer.ensureSufficientSpace(entrySize, tracer);
+  }
+
+  @Specialization
+  public void trace(final DirectMessage msg) {
+    ByteBuffer storage = getStorage(DIRECT_MSG_SIZE);
+
+    int pos = storage.position();
+
+    int idLen = id.execute(storage, pos + 1, ((TracingActor) msg.getSender()).getActorId());
+    int idBit = (idLen - 1) << 4;
+
+    storage.put((byte) (ActorExecutionTrace.MESSAGE | idBit));
+    storage.position(pos + idLen + 1);
+  }
+
+  @Specialization
+  public void trace(final ExternalDirectMessage msg) {
+    ByteBuffer storage = getStorage(EXT_DIRECT_MSG_SIZE);
+
+    int pos = storage.position();
+
+    int idLen = id.execute(storage, pos + 1,
+        ((TracingActor) msg.getSender()).getActorId());
+    int idBit = (idLen - 1) << 4;
+
+    storage.putByteAt(pos,
+        (byte) (ActorExecutionTrace.EXTERNAL_BIT | ActorExecutionTrace.MESSAGE | idBit));
+
+    pos += idLen;
+
+    storage.putShortAt(pos, msg.getMethod());
+    pos += 2;
+    storage.putIntAt(pos, msg.getDataId());
+    pos += 4;
+
+    storage.position(pos);
+  }
+
+  @Specialization
+  public void trace(final PromiseCallbackMessage msg) {
+    tracePromiseMsg(msg);
+  }
+
+  @Specialization
+  public void trace(final PromiseSendMessage msg) {
+    tracePromiseMsg(msg);
+  }
+
+  private void tracePromiseMsg(final PromiseMessage msg) {
+    ByteBuffer storage = getStorage(PROMISE_MSG_SIZE);
+
+    int pos = storage.position();
+
+    int idLen = idid.execute(storage, pos + 1,
+        ((TracingActor) msg.getSender()).getActorId(),
+        ((STracingPromise) msg.getPromise()).getResolvingActor());
+    int idBit = (idLen - 1) << 4;
+
+    storage.put((byte) (ActorExecutionTrace.PROMISE_MESSAGE | idBit));
+    storage.position(pos + idLen + idLen + 1);
+  }
+
+  @Specialization
+  public void trace(final ExternalPromiseCallbackMessage msg) {
+    traceExternalPromiseMsg(msg, msg.getMethod(), msg.getDataId());
+  }
+
+  @Specialization
+  public void trace(final ExternalPromiseSendMessage msg) {
+    traceExternalPromiseMsg(msg, msg.getMethod(), msg.getDataId());
+  }
+
+  private void traceExternalPromiseMsg(final PromiseMessage msg, final short method,
+      final int dataId) {
+    ByteBuffer storage = getStorage(EXT_PROMISE_MSG_SIZE);
+
+    int pos = storage.position();
+
+    int idLen = idid.execute(storage, pos + 1,
+        ((TracingActor) msg.getSender()).getActorId(),
+        ((STracingPromise) msg.getPromise()).getResolvingActor());
+    int idBit = (idLen - 1) << 4;
+
+    storage.putByteAt(pos,
+        (byte) (ActorExecutionTrace.EXTERNAL_BIT | ActorExecutionTrace.PROMISE_MESSAGE
+            | idBit));
+
+    pos += idLen + idLen;
+
+    storage.putShortAt(pos, method);
+    pos += 2;
+    storage.putIntAt(pos, dataId);
+    pos += 4;
+
+    storage.position(pos);
+  }
+}

--- a/src/tools/concurrency/nodes/TraceNode.java
+++ b/src/tools/concurrency/nodes/TraceNode.java
@@ -2,31 +2,11 @@ package tools.concurrency.nodes;
 
 import com.oracle.truffle.api.nodes.Node;
 
-import som.vm.VmSettings;
 import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
 import tools.concurrency.TracingActivityThread;
-import tools.concurrency.TracingActors.TracingActor;
 
 
 public abstract class TraceNode extends Node {
-
-  public abstract void execute(TracingActor actor);
-
-  protected static boolean smallIds() {
-    return VmSettings.TRACE_SMALL_IDS;
-  }
-
-  protected static boolean byteId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFFFFFF00) == 0;
-  }
-
-  protected static boolean shortId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFFFF0000) == 0;
-  }
-
-  protected static boolean threeByteId(final TracingActor actor) {
-    return (actor.getActorId() & 0xFF000000) == 0;
-  }
 
   protected static ActorTraceBuffer getCurrentBuffer() {
     TracingActivityThread t = TracingActivityThread.currentThread();

--- a/src/tools/concurrency/nodes/TraceNode.java
+++ b/src/tools/concurrency/nodes/TraceNode.java
@@ -1,0 +1,35 @@
+package tools.concurrency.nodes;
+
+import com.oracle.truffle.api.nodes.Node;
+
+import som.vm.VmSettings;
+import tools.concurrency.ActorExecutionTrace.ActorTraceBuffer;
+import tools.concurrency.TracingActivityThread;
+import tools.concurrency.TracingActors.TracingActor;
+
+
+public abstract class TraceNode extends Node {
+
+  public abstract void execute(TracingActor actor);
+
+  protected static boolean smallIds() {
+    return VmSettings.TRACE_SMALL_IDS;
+  }
+
+  protected static boolean byteId(final TracingActor actor) {
+    return (actor.getActorId() & 0xFFFFFF00) == 0;
+  }
+
+  protected static boolean shortId(final TracingActor actor) {
+    return (actor.getActorId() & 0xFFFF0000) == 0;
+  }
+
+  protected static boolean threeByteId(final TracingActor actor) {
+    return (actor.getActorId() & 0xFF000000) == 0;
+  }
+
+  protected static ActorTraceBuffer getCurrentBuffer() {
+    TracingActivityThread t = TracingActivityThread.currentThread();
+    return (ActorTraceBuffer) t.getBuffer();
+  }
+}

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -296,7 +296,9 @@ public class FrontendConnector {
 
   public void sendTracingData() {
     if (VmSettings.ACTOR_TRACING || VmSettings.MEDEOR_TRACING) {
-      TracingBackend.forceSwapBuffers();
+      // TODO: need to find a way to design this so that it does not interact strangely with
+      // the force for statistics
+      // TracingBackend.forceSwapBuffers();
     }
   }
 

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -254,7 +254,7 @@ public class FrontendConnector {
   }
 
   public void sendTracingData(final ByteBuffer b) {
-    traceSocket.send(b.getBuffer());
+    traceSocket.send(b.getReadingFromStartBuffer());
   }
 
   public void awaitClient() {

--- a/src/tools/debugger/FrontendConnector.java
+++ b/src/tools/debugger/FrontendConnector.java
@@ -3,7 +3,6 @@ package tools.debugger;
 import java.io.IOException;
 import java.net.BindException;
 import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
@@ -27,6 +26,7 @@ import tools.SourceCoordinate;
 import tools.SourceCoordinate.TaggedSourceCoordinate;
 import tools.Tagging;
 import tools.TraceData;
+import tools.concurrency.ByteBuffer;
 import tools.concurrency.TracingBackend;
 import tools.debugger.WebSocketHandler.MessageHandler;
 import tools.debugger.WebSocketHandler.TraceHandler;
@@ -254,7 +254,7 @@ public class FrontendConnector {
   }
 
   public void sendTracingData(final ByteBuffer b) {
-    traceSocket.send(b);
+    traceSocket.send(b.getBuffer());
   }
 
   public void awaitClient() {


### PR DESCRIPTION
- this is supposed to avoid the virtual methods on the JDK version
- might open up opportunities for performance improvements

**Not Tested**

`./fast -at -TF -EG core-lib/Benchmarks/AsyncHarness.ns Savina.ForkJoinActorCreation 1000 0 40000`

New ByteBuffer

```
1. 52157us
2. 56120us
3. 63595us
```

with: -t1
```
1. 35128us
2. 36269us
3. 35920us
```

JDK ByteBuffer

```
1. 61309us
2. 54627us
3. 55891us
```

with: -t1

```
1. 38202us
2. 37296us
3. 38560us
```

No tracing: 27740us