### PR TITLE
Assisted debugging

### DIFF
--- a/core-lib/Benchmarks/Savina.ns
+++ b/core-lib/Benchmarks/Savina.ns
@@ -80,7 +80,8 @@ class Savina usingPlatform: platform andHarness: harness = Value (
 
       public ping = (
         pong <-: ping: self.
-        self.writeMsg.
+        pingsLeft < (NumPings * 0.95)
+          ifTrue: [self.error: pingsLeft].
         pingsLeft:: pingsLeft - 1.
       )
 

--- a/core-lib/Benchmarks/Savina.ns
+++ b/core-lib/Benchmarks/Savina.ns
@@ -80,6 +80,7 @@ class Savina usingPlatform: platform andHarness: harness = Value (
 
       public ping = (
         pong <-: ping: self.
+        self.writeMsg.
         pingsLeft:: pingsLeft - 1.
       )
 

--- a/core-lib/Benchmarks/Savina.ns
+++ b/core-lib/Benchmarks/Savina.ns
@@ -80,7 +80,7 @@ class Savina usingPlatform: platform andHarness: harness = Value (
 
       public ping = (
         pong <-: ping: self.
-        pingsLeft < (NumPings * 0.95)
+        pingsLeft < (NumPings * 0.99)
           ifTrue: [self.error: pingsLeft].
         pingsLeft:: pingsLeft - 1.
       )

--- a/core-lib/Kernel.ns
+++ b/core-lib/Kernel.ns
@@ -69,7 +69,6 @@ class Kernel vmMirror: vmMirror = Object <: Value (
     (* Debugging *)
     public print    = ( self asString print )
     public println  = ( vmMirror printNewline: self asString )
-    public writeMsg = ( vmMirror writeErrorMsg: nil)
     public halt     = ( vmMirror halt: self )
     public asString = ( ^ 'instance of ' + (vmMirror objClassName: self) )
   )

--- a/core-lib/Kernel.ns
+++ b/core-lib/Kernel.ns
@@ -26,7 +26,7 @@ class Kernel vmMirror: vmMirror = Object <: Value (
   private class Top = ()()
 
   public class Thing = Top ()(
-    protected error: msg = ( vmMirror printNewline: 'ERROR: ' + msg. vmMirror exit: 1 )
+    protected error: msg = ( vmMirror printNewline: 'ERROR: ' + msg. vmMirror writeErrorMsg: nil. vmMirror exit: 1 )
 
     (* Error recovering *)
     protected doesNotUnderstand: selector arguments: arguments = (
@@ -69,6 +69,7 @@ class Kernel vmMirror: vmMirror = Object <: Value (
     (* Debugging *)
     public print    = ( self asString print )
     public println  = ( vmMirror printNewline: self asString )
+    public writeMsg = ( vmMirror writeErrorMsg: nil)
     public halt     = ( vmMirror halt: self )
     public asString = ( ^ 'instance of ' + (vmMirror objClassName: self) )
   )

--- a/core-lib/System.ns
+++ b/core-lib/System.ns
@@ -26,7 +26,7 @@ class System usingVmMirror: vmMirror = Value (
   public exit: error  = ( vmMirror exit: error )
   public exit         = ( self exit: 0 )
   public warning: msg = ( vmMirror printWarning: msg. )
-  public error: msg   = ( vmMirror printError: msg. self exit: 1 )
+  public error: msg   = ( vmMirror printError: msg. vmMirror writeErrorMsg: nil. self exit: 1 )
 
   (* VM *)
   public arguments    = ( ^ vmMirror vmArguments: nil )

--- a/som
+++ b/som
@@ -72,6 +72,8 @@ tools.add_argument('-wd', '--web-debugger', help='start Web debugger',
                     dest='web_debugger', action='store_true', default=False)
 tools.add_argument('-ad', '--assisted-debugging', help='enable assisted debugging',
                     dest='assisted_debugging', action='store_true', default=False)
+tools.add_argument('-adbp', '--assisted-debugging-breakpoints', help='set assisted debugging breakpoints limit',
+                    dest='assisted_debugging_breakpoints', default=0)
 tools.add_argument('-dm', '--dynamic-metrics', help='Capture Dynamic Metrics',
                     dest='dynamic_metrics', action='store_true', default=False)
 tools.add_argument('-si', '--si-candidates', help='Identify candidates for super-instructions',
@@ -311,7 +313,7 @@ if args.coverage:
 if args.java_coverage:
     flags += ['-javaagent:' + BASE_DIR + '/libs/jacoco/lib/jacocoagent.jar=inclbootstrapclasses=true,destfile=' + args.java_coverage]
 
-if args.web_debugger or args.assisted_debugging:
+if args.web_debugger:
     SOM_ARGS += ['--web-debug']
 if args.dynamic_metrics:
     SOM_ARGS += ['--dynamic-metrics']
@@ -351,14 +353,19 @@ if args.actor_snapshots_all:
     flags += ['-Dsom.actorSnapshotAll=true']
 
 if (args.truffle_profile or args.web_debugger or
-    args.dynamic_metrics or args.coverage or args.si_candidates or args.assisted_debugging):
+    args.dynamic_metrics or args.coverage or args.si_candidates):
     flags += ['-Dsom.instrumentation=true']
 
-if args.web_debugger or args.assisted_debugging:
+if args.web_debugger:
     flags += ['-Dsom.truffleDebugger=true']
 
 if args.assisted_debugging:
     flags += ['-Dsom.assistedDebugging=true']
+
+if args.assisted_debugging_breakpoints:
+    flags += ['-Dsom.assistedDebugging=true']
+if args.assisted_debugging_breakpoints:
+    flags += ['-Dsom.assistedDebuggingBp=%s' % args.assisted_debugging_breakpoints ]
 
 if not args.interpreter and args.perf_warnings:
     flags += ['-Dgraal.TruffleCompilationExceptionsAreFatal=true',

--- a/som
+++ b/som
@@ -70,6 +70,8 @@ profile.add_argument('-tp', '--truffle-profile', help='enable Graal-level profil
 tools = parser.add_argument_group('Tools', 'Additional Tools')
 tools.add_argument('-wd', '--web-debugger', help='start Web debugger',
                     dest='web_debugger', action='store_true', default=False)
+tools.add_argument('-ad', '--assisted-debugging', help='enable assisted debugging',
+                    dest='assisted_debugging', action='store_true', default=False)
 tools.add_argument('-dm', '--dynamic-metrics', help='Capture Dynamic Metrics',
                     dest='dynamic_metrics', action='store_true', default=False)
 tools.add_argument('-si', '--si-candidates', help='Identify candidates for super-instructions',
@@ -307,7 +309,7 @@ if args.coverage:
 if args.java_coverage:
     flags += ['-javaagent:' + BASE_DIR + '/libs/jacoco/lib/jacocoagent.jar=inclbootstrapclasses=true,destfile=' + args.java_coverage]
 
-if args.web_debugger:
+if args.web_debugger or args.assisted_debugging:
     SOM_ARGS += ['--web-debug']
 if args.dynamic_metrics:
     SOM_ARGS += ['--dynamic-metrics']
@@ -345,11 +347,14 @@ if args.actor_snapshots_all:
     flags += ['-Dsom.actorSnapshotAll=true']
 
 if (args.truffle_profile or args.web_debugger or
-    args.dynamic_metrics or args.coverage or args.si_candidates):
+    args.dynamic_metrics or args.coverage or args.si_candidates or args.assisted_debugging):
     flags += ['-Dsom.instrumentation=true']
 
-if args.web_debugger:
+if args.web_debugger or args.assisted_debugging:
     flags += ['-Dsom.truffleDebugger=true']
+
+if args.assisted_debugging:
+    flags += ['-Dsom.assistedDebugging=true']
 
 if not args.interpreter and args.perf_warnings:
     flags += ['-Dgraal.TruffleCompilationExceptionsAreFatal=true',

--- a/src/som/Launcher.java
+++ b/src/som/Launcher.java
@@ -55,7 +55,6 @@ public final class Launcher {
     }
 
     if(VmSettings.ASSISTED_DEBUGGING) {
-      TracingBackend.waitForTrace();
       KomposTraceParser tp = new KomposTraceParser();
       tp.createStackTraceFile(VmSettings.TRACE_FILE);
     }

--- a/src/som/Launcher.java
+++ b/src/som/Launcher.java
@@ -54,7 +54,7 @@ public final class Launcher {
       TracingBackend.reportPeakMemoryUsage();
     }
 
-    if(VmSettings.ASSISTED_DEBUGGING) {
+    if(VmSettings.KOMPOS_TRACING) {
       KomposTraceParser tp = new KomposTraceParser();
       tp.createStackTraceFile(VmSettings.TRACE_FILE);
     }

--- a/src/som/Launcher.java
+++ b/src/som/Launcher.java
@@ -11,6 +11,7 @@ import som.interpreter.SomLanguage;
 import som.interpreter.objectstorage.StorageAccessor;
 import som.vm.VmSettings;
 import tools.concurrency.TracingActors.ReplayActor;
+import tools.parser.KomposTraceParser;
 import tools.concurrency.TracingBackend;
 import tools.snapshot.SnapshotBackend;
 
@@ -51,6 +52,12 @@ public final class Launcher {
 
     if (VmSettings.MEMORY_TRACING) {
       TracingBackend.reportPeakMemoryUsage();
+    }
+
+    if(VmSettings.ASSISTED_DEBUGGING) {
+      TracingBackend.waitForTrace();
+      KomposTraceParser tp = new KomposTraceParser();
+      tp.createStackTraceFile(VmSettings.TRACE_FILE);
     }
 
     // TODO: TruffleException has a way to communicate exit code

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -170,32 +170,6 @@ public class Parser {
     return false;
   }
 
-  private static Set<Long> errorStrackTrace;
-
-  private static void getErrorStackTrace() {
-    errorStrackTrace = new HashSet<Long>();
-
-    File f = new File(VmSettings.TRACE_FILE + "_errorStack.trace");
-    try(Scanner sc = new Scanner(f)) {
-      long msgId = -1;
-      boolean found = false;
-      while(sc.hasNextLong() && !found) {
-        msgId = sc.nextLong();
-        errorStrackTrace.add(msgId);
-      }
-    }catch(FileNotFoundException e) {
-      
-    }
-  }
-
-  public static boolean isMessageInErrorStackTrace(long msgId) {
-    if(errorStrackTrace == null) {
-      getErrorStackTrace();
-    }
-
-    return errorStrackTrace.contains(msgId);
-  }
-
   @Override
   public String toString() {
     return "Parser(" + source.getName() + ", " + this.getCoordinate().toString() + ")";

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -68,10 +68,13 @@ import static som.interpreter.SNodeFactory.createMessageSend;
 import static som.interpreter.SNodeFactory.createSequence;
 import static som.vm.Symbols.symbolFor;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Scanner;
 import java.util.Set;
 
 import com.oracle.truffle.api.instrumentation.Tag;
@@ -165,6 +168,32 @@ public class Parser {
       }
     }
     return false;
+  }
+
+  private static Set<Long> errorStrackTrace;
+
+  private static void getErrorStackTrace() {
+    errorStrackTrace = new HashSet<Long>();
+
+    File f = new File(VmSettings.TRACE_FILE + "_errorStack.trace");
+    try(Scanner sc = new Scanner(f)) {
+      long msgId = -1;
+      boolean found = false;
+      while(sc.hasNextLong() && !found) {
+        msgId = sc.nextLong();
+        errorStrackTrace.add(msgId);
+      }
+    }catch(FileNotFoundException e) {
+      
+    }
+  }
+
+  public static boolean isMessageInErrorStackTrace(long msgId) {
+    if(errorStrackTrace == null) {
+      getErrorStackTrace();
+    }
+
+    return errorStrackTrace.contains(msgId);
   }
 
   @Override

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -1,6 +1,10 @@
 package som.interpreter.actors;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Scanner;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.RootCallTarget;
@@ -54,6 +58,11 @@ public abstract class EventualMessage {
     this.haltOnResolver = haltOnResolver;
     if (VmSettings.KOMPOS_TRACING) {
       this.messageId = TracingActivityThread.newEntityId();
+      if(VmSettings.ASSISTED_DEBUGGING) {
+        if(som.compiler.Parser.isMessageInErrorStackTrace(this.messageId)) {
+          this.haltOnReceive = true;
+        }
+      }
     } else {
       this.messageId = 0;
     }

--- a/src/som/interpreter/actors/EventualMessage.java
+++ b/src/som/interpreter/actors/EventualMessage.java
@@ -18,6 +18,7 @@ import som.vm.VmSettings;
 import som.vmobjects.SBlock;
 import som.vmobjects.SSymbol;
 import tools.concurrency.TracingActivityThread;
+import tools.parser.KomposTraceParser;
 import tools.snapshot.SnapshotBackend;
 import tools.snapshot.SnapshotBuffer;
 
@@ -59,7 +60,7 @@ public abstract class EventualMessage {
     if (VmSettings.KOMPOS_TRACING) {
       this.messageId = TracingActivityThread.newEntityId();
       if(VmSettings.ASSISTED_DEBUGGING) {
-        if(som.compiler.Parser.isMessageInErrorStackTrace(this.messageId)) {
+        if(KomposTraceParser.isMessageInErrorStackTrace(this.messageId) || this.messageId == 0){
           this.haltOnReceive = true;
         }
       }

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -228,7 +228,7 @@ public final class SystemPrims {
         EventualMessage errorMsg = EventualMessage.getCurrentExecutingMessage();
         long msgId = errorMsg.getMessageId();
 
-        File f = new File(VmSettings.TRACE_FILE + "_errorMsgId" + ".trace");
+        File f = new File(VmSettings.TRACE_FILE + "_errorMsgId.trace");
         try(
           BufferedWriter writer = new BufferedWriter(new FileWriter(f))) {
           writer.write(String.valueOf(msgId));

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -223,7 +223,7 @@ public final class SystemPrims {
   public abstract static class WriteErrorMsgPrim extends UnaryExpressionNode {
     @Specialization
     public final Object doSObject(final Object receiver) {
-      if(VmSettings.KOMPOS_TRACING && VmSettings.ASSISTED_DEBUGGING) {
+      if(VmSettings.KOMPOS_TRACING) {
         
         EventualMessage errorMsg = EventualMessage.getCurrentExecutingMessage();
         long msgId = errorMsg.getMessageId();

--- a/src/som/primitives/SystemPrims.java
+++ b/src/som/primitives/SystemPrims.java
@@ -1,7 +1,9 @@
 package som.primitives;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -213,6 +215,30 @@ public final class SystemPrims {
     public final Object doSObject(final String argument) {
       Output.errorPrintln(argument);
       return argument;
+    }
+  }
+    
+  @GenerateNodeFactory
+  @Primitive(primitive = "writeErrorMsg:")
+  public abstract static class WriteErrorMsgPrim extends UnaryExpressionNode {
+    @Specialization
+    public final Object doSObject(final Object receiver) {
+      if(VmSettings.KOMPOS_TRACING && VmSettings.ASSISTED_DEBUGGING) {
+        
+        EventualMessage errorMsg = EventualMessage.getCurrentExecutingMessage();
+        long msgId = errorMsg.getMessageId();
+
+        File f = new File(VmSettings.TRACE_FILE + "_errorMsgId" + ".trace");
+        try(
+          BufferedWriter writer = new BufferedWriter(new FileWriter(f))) {
+          writer.write(String.valueOf(msgId));
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        
+        Output.println("ERROR MSG-ID: " + msgId);
+      }
+      return receiver;
     }
   }
 

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -19,6 +19,7 @@ public class VmSettings implements Settings {
   public static final boolean REPLAY;
   public static final boolean KOMPOS_TRACING;
   public static final boolean ASSISTED_DEBUGGING;
+  
   public static final boolean TRACE_SMALL_IDS;
   public static final boolean SNAPSHOTS_ENABLED;
   public static final boolean TRACK_SNAPSHOT_ENTITIES;
@@ -35,6 +36,7 @@ public class VmSettings implements Settings {
 
   public static final int     BUFFERS_PER_THREAD;
   public static final int     BUFFER_SIZE;
+  public static final int     ASSISTED_DEBUGGING_BREAKPOINTS;
   public static final boolean RECYCLE_BUFFERS;
   public static final int     BUFFER_TIMEOUT;
 
@@ -78,6 +80,7 @@ public class VmSettings implements Settings {
     IGV_DUMP_AFTER_PARSING = getBool("som.igvDumpAfterParsing", false);
     ANSI_COLOR_IN_OUTPUT = getBool("som.useAnsiColoring", false);
 
+    ASSISTED_DEBUGGING_BREAKPOINTS = getInteger("som.assistedDebuggingBp", -1);
     BUFFER_SIZE = getInteger("som.buffSize", 1024 * 1024);
     BUFFERS_PER_THREAD = getInteger("som.buffPerThread", 4);
     BUFFER_TIMEOUT = getInteger("som.buffDelay", 50);

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -57,7 +57,7 @@ public class VmSettings implements Settings {
     MEMORY_TRACING = getBool("som.memoryTracing", false);
     REPLAY = getBool("som.replay", false);
     KOMPOS_TRACING = TRUFFLE_DEBUGGER_ENABLED; // REPLAY;
-    ASSISTED_DEBUGGING = getBool("som.assistedDebugging", true) && KOMPOS_TRACING;
+    ASSISTED_DEBUGGING = getBool("som.assistedDebugging", false) && KOMPOS_TRACING;
     DISABLE_TRACE_FILE = getBool("som.disableTraceFile", false) || REPLAY;
     TRACE_SMALL_IDS = getBool("som.smallIds", false);
 

--- a/src/som/vm/VmSettings.java
+++ b/src/som/vm/VmSettings.java
@@ -18,6 +18,7 @@ public class VmSettings implements Settings {
   public static final boolean DNU_PRINT_STACK_TRACE;
   public static final boolean REPLAY;
   public static final boolean KOMPOS_TRACING;
+  public static final boolean ASSISTED_DEBUGGING;
   public static final boolean TRACE_SMALL_IDS;
   public static final boolean SNAPSHOTS_ENABLED;
   public static final boolean TRACK_SNAPSHOT_ENTITIES;
@@ -56,6 +57,7 @@ public class VmSettings implements Settings {
     MEMORY_TRACING = getBool("som.memoryTracing", false);
     REPLAY = getBool("som.replay", false);
     KOMPOS_TRACING = TRUFFLE_DEBUGGER_ENABLED; // REPLAY;
+    ASSISTED_DEBUGGING = getBool("som.assistedDebugging", true) && KOMPOS_TRACING;
     DISABLE_TRACE_FILE = getBool("som.disableTraceFile", false) || REPLAY;
     TRACE_SMALL_IDS = getBool("som.smallIds", false);
 

--- a/src/tools/concurrency/TracingBackend.java
+++ b/src/tools/concurrency/TracingBackend.java
@@ -38,6 +38,7 @@ import som.vmobjects.SArray;
 import som.vmobjects.SArray.SImmutableArray;
 import som.vmobjects.SSymbol;
 import tools.debugger.FrontendConnector;
+import tools.parser.KomposTraceParser;
 import tools.replay.StringWrapper;
 import tools.replay.TwoDArrayWrapper;
 import tools.replay.actors.ActorExecutionTrace;
@@ -589,6 +590,7 @@ public class TracingBackend {
           } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
           }
+
         }
       } catch (IOException e) {
         throw new RuntimeException(e);

--- a/src/tools/parser/KomposTraceParser.java
+++ b/src/tools/parser/KomposTraceParser.java
@@ -218,25 +218,28 @@ public class KomposTraceParser {
 
     public void createStackTraceFile(String path) {
         File errorMsgFile = new File(path + "_errorMsgId.trace");
-        long errorMsgId = -1;
 
-        try (Scanner sc = new Scanner(errorMsgFile)){
-            errorMsgId = sc.nextLong();
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        }
+        if(errorMsgFile.exists() && !errorMsgFile.isDirectory()) {
+            long errorMsgId = -1;
 
-        if(errorMsgId != -1) {
-            parse(path + ".trace");
-            List<MsgObj> stackTrace = getStrackTraceOfMessage(errorMsgId);
-            File stackTraceFile = new File(path + "_errorStack.trace");
-
-            try(BufferedWriter writer = new BufferedWriter(new FileWriter(stackTraceFile))) {
-                for (MsgObj msg:stackTrace) {
-                    writer.write(String.valueOf(msg.messageId) + "\n");
-                }
-            } catch (IOException e) {
+            try (Scanner sc = new Scanner(errorMsgFile)){
+                errorMsgId = sc.nextLong();
+            } catch (FileNotFoundException e) {
                 e.printStackTrace();
+            }
+
+            if(errorMsgId != -1) {
+                parse(path + ".trace");
+                List<MsgObj> stackTrace = getStrackTraceOfMessage(errorMsgId);
+                File stackTraceFile = new File(path + "_errorStack.trace");
+
+                try(BufferedWriter writer = new BufferedWriter(new FileWriter(stackTraceFile))) {
+                    for (MsgObj msg:stackTrace) {
+                        writer.write(String.valueOf(msg.messageId) + "\n");
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
         }
     }

--- a/src/tools/parser/KomposTraceParser.java
+++ b/src/tools/parser/KomposTraceParser.java
@@ -1,0 +1,250 @@
+package tools.parser;
+
+import java.awt.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.util.*;
+import java.util.List;
+
+import tools.debugger.entities.Marker;
+
+public class KomposTraceParser {
+
+    private static final int SOURCE_SECTION_SIZE = 8;
+
+    private enum TraceRecords {
+        ActivityCreation(11 + SOURCE_SECTION_SIZE),
+        ActivityCompletion(1),
+        DynamicScopeStart(9 + SOURCE_SECTION_SIZE),
+        DynamicScopeEnd(1),
+        PassiveEntityCreation(9 + SOURCE_SECTION_SIZE),
+        PassiveEntityCompletion(0),
+        SendOp(17),
+        ReceiveOp(9),
+        ImplThread(9),
+        ImplThreadCurrentActivity(13);
+
+        private int byteSize;
+
+        TraceRecords(int byteSize) {
+            this.byteSize = byteSize;
+        }
+
+        public int getByteSize() {
+            return byteSize;
+        }
+    }
+
+    private final List<Long> turns = new ArrayList<Long>();
+    private final TraceRecords[] parseTable = createParseTable();
+    private final ByteBuffer byteBuffer = ByteBuffer.allocate(2048);
+
+    private final HashMap<Long, MsgObj> messages = new HashMap<Long, MsgObj>();
+
+    private final List<Long> toResolvePromises = new ArrayList<Long>();
+
+    public KomposTraceParser() {
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    private TraceRecords[] createParseTable() {
+        TraceRecords[] result = new TraceRecords[23];
+
+        result[Marker.PROCESS_CREATION] = TraceRecords.ActivityCreation;
+        result[Marker.PROCESS_COMPLETION] = TraceRecords.ActivityCompletion;
+        result[Marker.ACTOR_CREATION] = TraceRecords.ActivityCreation;
+        result[Marker.TASK_SPAWN] = TraceRecords.ActivityCreation;
+        result[Marker.THREAD_SPAWN] = TraceRecords.ActivityCreation;
+
+        result[Marker.ACTOR_MSG_SEND] = TraceRecords.SendOp;
+        result[Marker.PROMISE_MSG_SEND] = TraceRecords.SendOp;
+        result[Marker.CHANNEL_MSG_SEND] = TraceRecords.SendOp;
+        result[Marker.PROMISE_RESOLUTION] = TraceRecords.SendOp;
+
+        result[Marker.CHANNEL_MSG_RCV] = TraceRecords.ReceiveOp;
+        result[Marker.TASK_JOIN] = TraceRecords.ReceiveOp;
+        result[Marker.THREAD_JOIN] = TraceRecords.ReceiveOp;
+
+        result[Marker.TURN_START] = TraceRecords.DynamicScopeStart;
+        result[Marker.TURN_END] = TraceRecords.DynamicScopeEnd;
+        result[Marker.MONITOR_ENTER] = TraceRecords.DynamicScopeStart;
+        result[Marker.MONITOR_EXIT] = TraceRecords.DynamicScopeEnd;
+        result[Marker.TRANSACTION_START] = TraceRecords.DynamicScopeStart;
+        result[Marker.TRANSACTION_END] = TraceRecords.DynamicScopeEnd;
+
+        result[Marker.CHANNEL_CREATION] = TraceRecords.PassiveEntityCreation;
+        result[Marker.PROMISE_CREATION] = TraceRecords.PassiveEntityCreation;
+
+        result[Marker.IMPL_THREAD] = TraceRecords.ImplThread;
+        result[Marker.IMPL_THREAD_CURRENT_ACTIVITY] = TraceRecords.ImplThreadCurrentActivity;
+
+        return result;
+    }
+
+    private void parse(String path) {
+        File traceFile = new File(path);
+
+        long currentTurn = -1;
+        try {
+            FileInputStream fis = new FileInputStream(traceFile);
+            FileChannel channel = fis.getChannel();
+
+            channel.read(byteBuffer);
+            byteBuffer.flip();
+
+            long currentActivityId = -1;
+
+
+            while(channel.position() < channel.size() || byteBuffer.remaining() > 0) {
+                if (!byteBuffer.hasRemaining()) {
+                    byteBuffer.clear();
+                    channel.read(byteBuffer);
+                    byteBuffer.flip();
+                } else if (byteBuffer.remaining() < 20) {
+                    byteBuffer.compact();
+                    channel.read(byteBuffer);
+                    byteBuffer.flip();
+                }
+
+                final int start = byteBuffer.position();
+                final byte type = byteBuffer.get();
+
+                TraceRecords recordType = parseTable[type];
+
+                switch (recordType) {
+                    case ActivityCreation:
+                        long activityId = byteBuffer.getLong();
+                        short symboldId = byteBuffer.getShort();
+                        readSourceSection();
+                        assert byteBuffer.position() == start + (TraceRecords.ActivityCreation.getByteSize());
+                        break;
+                    case ActivityCompletion:
+                        assert byteBuffer.position() == start + (TraceRecords.ActivityCompletion.getByteSize());
+                        break;
+                    case DynamicScopeStart:
+                        long id = byteBuffer.getLong();
+                        turns.add(id);
+                        if(type == Marker.TURN_START) {
+                            currentTurn = id;
+                            if(toResolvePromises.contains(id)) {
+                                MsgObj message = messages.get(id);
+                                message.receiverId = currentActivityId;
+                                toResolvePromises.remove(id);
+                            }
+                        }
+
+                        readSourceSection();
+                        assert byteBuffer.position() == start + (TraceRecords.DynamicScopeStart.getByteSize());
+                        break;
+                    case DynamicScopeEnd:
+                        assert byteBuffer.position() == start + (TraceRecords.DynamicScopeEnd.getByteSize());
+                        break;
+                    case SendOp:
+                        long entityId = byteBuffer.getLong();
+                        long targetId = byteBuffer.getLong();
+
+                        if (type == Marker.ACTOR_MSG_SEND) {
+                            messages.put(entityId, new MsgObj(entityId ,currentActivityId, targetId, currentTurn));
+                        }
+
+                        if(type == Marker.PROMISE_MSG_SEND) {
+                            messages.put(entityId, new PromiseObj(entityId, currentActivityId, currentTurn, targetId));
+                            // Need to retrieve Target from turn
+                            toResolvePromises.add(entityId);
+                        }
+
+                        assert byteBuffer.position() == start + (TraceRecords.SendOp.getByteSize());
+                        break;
+                    case ReceiveOp:
+                        long sourceId = byteBuffer.getLong();
+                        assert byteBuffer.position() == start + (TraceRecords.ReceiveOp.getByteSize());
+                    case PassiveEntityCreation:
+                        id = byteBuffer.getLong();
+                        readSourceSection();
+                        assert byteBuffer.position() == start + (TraceRecords.PassiveEntityCreation.getByteSize());
+                        break;
+                    case PassiveEntityCompletion:
+                        assert byteBuffer.position() == start + (TraceRecords.PassiveEntityCompletion.getByteSize());
+                        break;
+                    case ImplThread:
+                        long currentImplThreadId = byteBuffer.getLong();
+                        assert byteBuffer.position() == start + (TraceRecords.ImplThread.getByteSize());
+                        break;
+                    case ImplThreadCurrentActivity:
+                        currentActivityId = byteBuffer.getLong();
+                        int currentActivityBufferId = byteBuffer.getInt();
+                        assert byteBuffer.position() == start + (TraceRecords.ImplThreadCurrentActivity.getByteSize());
+                        break;
+                    default:
+                        assert false;
+                }
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private List<MsgObj> getStrackTraceOfMessage(long messageId) {
+        List<MsgObj> stackTrace = new ArrayList<MsgObj>();
+
+        if (!messages.containsKey(messageId)) {
+            throw new IllegalArgumentException();
+        }
+
+        MsgObj message = messages.get(messageId);
+        stackTrace.add(message);
+
+        while(message.parentMsgId != -1) {
+            if (messages.containsKey(message.parentMsgId)) {
+                message = messages.get(message.parentMsgId);
+                stackTrace.add(message);
+            } else {
+                System.out.println("Message not found?!");
+                break;
+            }
+        }
+
+        return stackTrace;
+    }
+
+    public void createStackTraceFile(String path) {
+        File errorMsgFile = new File(path + "_errorMsgId.trace");
+        long errorMsgId = -1;
+
+        try (Scanner sc = new Scanner(errorMsgFile)){
+            errorMsgId = sc.nextLong();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        if(errorMsgId != -1) {
+            parse(path + ".trace");
+            List<MsgObj> stackTrace = getStrackTraceOfMessage(errorMsgId);
+            File stackTraceFile = new File(path + "_errorStack.trace");
+
+            try(BufferedWriter writer = new BufferedWriter(new FileWriter(stackTraceFile))) {
+                for (MsgObj msg:stackTrace) {
+                    writer.write(String.valueOf(msg.messageId) + "\n");
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void readSourceSection() {
+        short fileId = byteBuffer.getShort();
+        short startLine = byteBuffer.getShort();
+        short startCol = byteBuffer.getShort();
+        short charLen = byteBuffer.getShort();
+    }
+}

--- a/src/tools/parser/MsgObj.java
+++ b/src/tools/parser/MsgObj.java
@@ -1,0 +1,22 @@
+package tools.parser;
+
+public class MsgObj {
+    long messageId;
+    long senderId;
+    long receiverId;
+    long parentMsgId;
+
+    public MsgObj(long messageId, long senderId, long parentMsgId) {
+        this.messageId = messageId;
+        this.senderId = senderId;
+        this.parentMsgId = parentMsgId;
+    }
+
+
+    public MsgObj(long messageId,long senderId, long receiverId, long parentMsgId) {
+        this.messageId = messageId;
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+        this.parentMsgId = parentMsgId;
+    }
+}

--- a/src/tools/parser/PromiseObj.java
+++ b/src/tools/parser/PromiseObj.java
@@ -1,0 +1,10 @@
+package tools.parser;
+
+public class PromiseObj extends MsgObj {
+    long promiseId;
+
+    public PromiseObj(long messageId, long senderId, long parentMsgId, long promiseId) {
+        super(messageId, senderId, parentMsgId);
+        this.promiseId = promiseId;
+    }
+}


### PR DESCRIPTION
Added assisted debugging with 2 flags:
-ad = enable assisted debugging with all parent messages of error
-adbp [int] = enable assisted debugging with an int parameter specifying how many messages should receive a breakpoint. The parameter -1 is equivalent to -ad. 

Todo:
- Check why breakpoint for message 0 is needed
- Properly create breakpoints instead of by-passing the check by setting the boolean flag "isHaltOnReceive"
- Fix -kt